### PR TITLE
Add request debouncing with bundling

### DIFF
--- a/app/scripts/config.js
+++ b/app/scripts/config.js
@@ -83,7 +83,7 @@ export const tracksInfo = [
         type: 'viewport-projection-center',
         datatype: ['2d-projection'],
         local: true,
-        hidden: true,  
+        hidden: true,
         orientation: '2d',
         name: 'Viewport Projection',
         thumbnail: 'viewport-projection-center.png'
@@ -114,3 +114,4 @@ export const tracksInfo = [
     }
 ]
 
+export const TILE_FETCH_DEBOUNCE = 100;


### PR DESCRIPTION
The debouncing bundles the request by the TiledPixiTrack instances. The worker bundles the request by server and only sends of unique tile IDs (in case multiple instances request the same tile).

One important thing to note: right now the benefit is limited as the worker is relying on GET requests with URL encoding of tile ids, which is limited to 10 tiles per request. I'd suggest allowing POST requests on the server side and sending a JSON object with an array of all IDs. This would allow to send one request for an arbitrary large number of tiles.