### PR TITLE
Flekschas/initial domain fix

### DIFF
--- a/app/bug.html
+++ b/app/bug.html
@@ -1,0 +1,340 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>HiGlass</title>
+<style type="text/css">
+    .canvasjs-chart-credit {
+    display:none;
+}
+</style>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/latest/css/bootstrap.min.css">
+    <link rel="stylesheet" href="styles/page.css">
+</head>
+<body >
+    <div style="height: 50px" />
+        <div style="margin: auto; width: 100%;">
+        <div
+            id="development-demo"
+            style="position: absolute; left: 0px; top: 0px; bottom: 0px; right: 0px">
+        </div>
+    </div>
+</body>
+<script src='scripts/hglib.js'>
+</script>
+<script>
+
+ var testViewConfig =
+{
+  "editable": true,
+  "zoomFixed": false,
+  "trackSourceServers": [
+    "http://higlass.io/api/v1"
+  ],
+  "exportViewUrl": "http://higlass.io/api/v1/viewconfs/",
+  "views": [
+    {
+      "uid": "aa",
+            "initialXDomain": [
+                0,3000000000
+                                          ],
+            "initialYDomain": [
+                0,3000000000
+                                          ],
+      "autocompleteSource": "http://higlass.io/api/v1/suggest/?d=OHJakQICQD6gTD7skx4EWA&",
+      "genomePositionSearchBoxVisible": true,
+      "chromInfoPath": "//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv",
+      "tracks": {
+        "top": [
+                  {
+            "uuid": "OHJakQICQD6gTD7skx4EWA",
+            "filetype": "beddb",
+            "datatype": "gene-annotation",
+            "private": false,
+            "name": "Gene Annotations (hg19)",
+            "coordSystem": "hg19",
+            "coordSystem2": "",
+            "server": "http://higlass.io/api/v1",
+            "tilesetUid": "OHJakQICQD6gTD7skx4EWA",
+            "serverUidKey": "http://higlass.io/api/v1/OHJakQICQD6gTD7skx4EWA",
+            "uid": "BEEMEjU7QCa2krDO9C0yOQ",
+            "type": "horizontal-gene-annotations",
+            "options": {
+                "labelPosition": "outerTop",
+              "name": "Gene Annotations (hg19)"
+            },
+            "width": 20,
+            "height": 60,
+            "maxWidth": 4294967296,
+            "maxZoom": 22
+          },
+         {
+            "filetype": "hitile",
+            "datatype": "vector",
+            "private": false,
+            "name": "wgEncodeSydhTfbsGm12878Rad21IggrabSig.hitile",
+            "coordSystem": "hg19",
+            "coordSystem2": "",
+            "server": "http://higlass.io/api/v1",
+            "tilesetUid": "F2vbUeqhS86XkxuO1j2rPA",
+            "serverUidKey": "http://higlass.io/api/v1/F2vbUeqhS86XkxuO1j2rPA",
+            "type": "horizontal-line",
+            "options": {
+              "labelColor": "red",
+              "labelPosition": "outerLeft",
+              "axisPositionHorizontal": "right",
+              "lineStrokeColor": "blue",
+              "name": "wgEncodeSydhTfbsGm12878Rad21IggrabSig.hitile",
+              "valueScaling": "log"
+            },
+            "width": 20,
+            "height": 20,
+            "maxWidth": 4294967296,
+            "maxZoom": 22
+          },
+          {
+            "chromInfoPath": "//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv",
+            "type": "horizontal-chromosome-labels",
+            "position": "top",
+            "name": "Chromosome Labels (hg19)",
+            "height": 30,
+            "uid": "I1QUF22JQJuJ38j9PS4iqw",
+            "options": {}
+          }
+        ],
+        "left": [
+          {
+            "type": "vertical-gene-annotations",
+            "width": 60,
+            "tilesetUid": "OHJakQICQD6gTD7skx4EWA",
+            "server": "http://higlass.io/api/v1",
+            "position": "left",
+            "name": "Gene Annotations (hg19)",
+            "options": {
+              "labelPosition": "bottomRight",
+              "name": "Gene Annotations (hg19)"
+            },
+            "uid": "OgnAEKSHRaG-gR1RqPOuBQ",
+            "maxWidth": 4294967296,
+            "maxZoom": 22
+          },
+          {
+            "chromInfoPath": "//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv",
+            "type": "vertical-chromosome-labels",
+            "position": "left",
+            "name": "Chromosome Labels (hg19)",
+            "width": 30,
+            "uid": "a-mFiHnBQ8uuI6UG3USWVA",
+            "options": {}
+          }
+        ],
+        "center": [
+          {
+            "uid": "c1",
+            "type": "combined",
+            "height": 200,
+            "contents": [
+              {
+                "server": "http://higlass.io/api/v1",
+                "tilesetUid": "CQMd6V_cRw6iCI_-Unl3PQ",
+                "type": "heatmap",
+                "position": "center",
+                "options": {
+                  "colorRange": [
+                    "#FFFFFF",
+                    "#F8E71C",
+                    "#F5A623",
+                    "#D0021B"
+                  ],
+                  "maxZoom": null,
+                  "labelPosition": "bottomRight",
+                  "name": "Rao et al. (2014) GM12878 MboI (allreps) 1kb"
+                },
+                "uid": "Ou4CIWdfSOqAucehIgPwgA",
+                "name": "Rao et al. (2014) GM12878 MboI (allreps) 1kb",
+                "maxWidth": 4194304000,
+                "binsPerDimension": 256,
+                "maxZoom": 14
+              },
+              {
+                "type": "2d-chromosome-grid",
+                "datatype": [
+                  "chromosome-2d-grid"
+                ],
+                "local": true,
+                "orientation": "2d",
+                "name": "Chromosome Grid (hg19)",
+                "chromInfoPath": "//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv",
+                "thumbnail": null,
+                "uuid": "TIlwFtqxTX-ndtM7Y9k1bw",
+                "server": "",
+                "tilesetUid": "TIlwFtqxTX-ndtM7Y9k1bw",
+                "serverUidKey": "/TIlwFtqxTX-ndtM7Y9k1bw",
+                "uid": "LUVqXXu2QYiO8XURIwyUyA",
+                "options": {}
+              }
+
+            ],
+            "position": "center",
+            "options": {}
+          }
+        ],
+        "right": [
+          {
+            "type": "vertical-gene-annotations",
+            "width": 60,
+            "tilesetUid": "OHJakQICQD6gTD7skx4EWA",
+            "server": "http://higlass.io/api/v1",
+            "name": "Gene Annotations (hg19)",
+            "options": {
+              "labelPosition": "outerBottom",
+              "name": "Gene Annotations (hg19)"
+            },
+            "maxWidth": 4294967296,
+            "maxZoom": 22
+          },
+          {
+            "chromInfoPath": "//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv",
+            "type": "vertical-chromosome-labels",
+            "name": "Chromosome Labels (hg19)",
+            "width": 30,
+            "options": {
+                "labelPosition": "outerBottom",
+                "name": "Chromosome labels"
+            }
+          }
+        ],
+        "bottom": [
+         {
+            "filetype": "hitile",
+            "datatype": "vector",
+            "private": false,
+            "name": "wgEncodeSydhTfbsGm12878Rad21IggrabSig.hitile",
+            "coordSystem": "hg19",
+            "coordSystem2": "",
+            "server": "http://higlass.io/api/v1",
+            "tilesetUid": "F2vbUeqhS86XkxuO1j2rPA",
+            "serverUidKey": "http://higlass.io/api/v1/F2vbUeqhS86XkxuO1j2rPA",
+            "type": "horizontal-line",
+            "options": {
+              "labelPosition": "outerLeft",
+              "axisPositionHorizontal": "right",
+              "lineStrokeColor": "blue",
+              "name": "wgEncodeSydhTfbsGm12878Rad21IggrabSig.hitile",
+              "valueScaling": "log"
+            },
+            "width": 20,
+            "height": 50,
+            "maxWidth": 4294967296,
+            "maxZoom": 22
+          },
+        ]
+      },
+      "layout": {
+        "w": 12,
+        "h": 12,
+        "x": 0,
+        "y": 0,
+        "i": "aa",
+        "moved": false,
+        "static": false
+      }
+    }
+  ],
+  "zoomLocks": {
+    "locksByViewUid": {},
+    "locksDict": {}
+  },
+  "locationLocks": {
+    "locksByViewUid": {},
+    "locksDict": {}
+  }
+}
+ ;
+
+
+ var testconfig2 = {"editable":false,"chromInfoPath":"//localhost:8000/api/v1/chrom-info?coords=hg19","trackSourceServers":["/api/v1"],"exportViewUrl":"//higlass.io/api/v1/viewconfs/","views":[{"uid":"a","initialXDomain":[2829728720,2881033286],"initialYDomain":[2829728720,2881033286],"autocompleteSource":"//higlass.io/api/v1/suggest/?d=OHJakQICQD6gTD7skx4EWA&","genomePositionSearchBoxVisible":true,"chromInfoPath":"//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv","tracks":{"top":[{"uid":"b","type":"horizontal-gene-annotations","height":60,"tilesetUid":"OHJakQICQD6gTD7skx4EWA","server":"//higlass.io/api/v1","name":"Gene Annotations","options":{"name":"Gene Annotations (hg19)","minusStrandColor":"#999","plusStrandColor":"#999"}},{"uid":"c","chromInfoPath":"//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv","type":"horizontal-chromosome-labels","name":"Chromosome Labels (hg19)","height":30}],"left":[{"uid":"d","chromInfoPath":"//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv","type":"vertical-chromosome-labels","name":"Chromosome Labels (hg19)","width":30}],"center":[{"uid":"e","type":"combined","height":200,"contents":[{"uid":"f","server":"//localhost:8000/api/v1","tilesetUid":"rao1kbmr","type":"heatmap","options":{"colorRange":["#fff","#bbb","#777","#222"],"maxZoom":null,"name":"Rao et al. (2014) GM12878 MboI (allreps) 1kb"}}],"position":"center"},{"uid":"a.2d","type":"2d-chromosome-annotations","chromInfoPath":"//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv","options":{"minRectWidth":2,"minRectHeight":2,"regions":[["chr22",17395000,17400000,"chr22",17535000,17540000,"rgba(255, 85, 0, 0.8)","cyan"],["chr22",17400000,17410000,"chr22",17980000,17990000,"rgba(255, 85, 0, 0.8)"],["chr22",17650000,17655000,"chr22",17980000,17985000,"rgba(255, 85, 0, 0.8)"],["chr22",17690000,17700000,"chr22",18250000,18260000,"rgba(255, 85, 0, 0.8)"],["chr22",18310000,18315000,"chr22",18550000,18555000,"rgba(255, 85, 0, 0.8)"],["chr22",18590000,18595000,"chr22",18625000,18630000,"rgba(255, 85, 0, 0.8)"],["chr22",18940000,18950000,"chr22",20260000,20270000,"rgba(255, 85, 0, 0.8)"],["chr22",19160000,19165000,"chr22",19460000,19465000,"rgba(255, 85, 0, 0.8)"],["chr22",19720000,19725000,"chr22",19900000,19905000,"rgba(255, 85, 0, 0.8)"],["chr22",20145000,20150000,"chr22",20270000,20275000,"rgba(255, 85, 0, 0.8)"],["chr22",20765000,20770000,"chr22",20810000,20815000,"rgba(255, 85, 0, 0.8)"],["chr22",20770000,20780000,"chr22",21050000,21060000,"rgba(255, 85, 0, 0.8)"],["chr22",20940000,20950000,"chr22",21050000,21060000,"rgba(255, 85, 0, 0.8)"],["chr22",20960000,20965000,"chr22",21040000,21045000,"rgba(255, 85, 0, 0.8)"],["chr22",22060000,22065000,"chr22",22295000,22300000,"rgba(255, 85, 0, 0.8)"],["chr22",22380000,22385000,"chr22",23250000,23255000,"rgba(255, 85, 0, 0.8)"],["chr22",22380000,22390000,"chr22",23280000,23290000,"rgba(255, 85, 0, 0.8)"],["chr22",22520000,22525000,"chr22",23480000,23485000,"rgba(255, 85, 0, 0.8)"],["chr22",22535000,22540000,"chr22",23245000,23250000,"rgba(255, 85, 0, 0.8)"],["chr22",22535000,22540000,"chr22",23285000,23290000,"rgba(255, 85, 0, 0.8)"],["chr22",22705000,22710000,"chr22",23280000,23285000,"rgba(255, 85, 0, 0.8)"],["chr22",22930000,22940000,"chr22",23030000,23040000,"rgba(255, 85, 0, 0.8)"],["chr22",23155000,23160000,"chr22",23190000,23195000,"rgba(255, 85, 0, 0.8)"],["chr22",23170000,23180000,"chr22",23630000,23640000,"rgba(255, 85, 0, 0.8)"],["chr22",23195000,23200000,"chr22",23280000,23285000,"rgba(255, 85, 0, 0.8)"],["chr22",23270000,23280000,"chr22",50970000,50980000,"rgba(255, 85, 0, 0.8)"],["chr22",23300000,23305000,"chr22",23625000,23630000,"rgba(255, 85, 0, 0.8)"],["chr22",23300000,23310000,"chr22",23720000,23730000,"rgba(255, 85, 0, 0.8)"],["chr22",23305000,23310000,"chr22",23465000,23470000,"rgba(255, 85, 0, 0.8)"],["chr22",23520000,23525000,"chr22",23620000,23625000,"rgba(255, 85, 0, 0.8)"],["chr22",23680000,23690000,"chr22",25070000,25080000,"rgba(255, 85, 0, 0.8)"],["chr22",23880000,23890000,"chr22",24100000,24110000,"rgba(255, 85, 0, 0.8)"],["chr22",23885000,23890000,"chr22",24190000,24195000,"rgba(255, 85, 0, 0.8)"],["chr22",23935000,23940000,"chr22",25830000,25835000,"rgba(255, 85, 0, 0.8)"],["chr22",23970000,23980000,"chr22",24190000,24200000,"rgba(255, 85, 0, 0.8)"],["chr22",23980000,23985000,"chr22",25710000,25715000,"rgba(255, 85, 0, 0.8)"],["chr22",24110000,24115000,"chr22",24190000,24195000,"rgba(255, 85, 0, 0.8)"],["chr22",24715000,24720000,"chr22",24915000,24920000,"rgba(255, 85, 0, 0.8)"],["chr22",24820000,24830000,"chr22",24910000,24920000,"rgba(255, 85, 0, 0.8)"],["chr22",25030000,25040000,"chr22",25140000,25150000,"rgba(255, 85, 0, 0.8)"],["chr22",25690000,25695000,"chr22",25985000,25990000,"rgba(255, 85, 0, 0.8)"],["chr22",25850000,25860000,"chr22",26720000,26730000,"rgba(255, 85, 0, 0.8)"],["chr22",25855000,25860000,"chr22",26170000,26175000,"rgba(255, 85, 0, 0.8)"],["chr22",26170000,26175000,"chr22",26725000,26730000,"rgba(255, 85, 0, 0.8)"],["chr22",26290000,26295000,"chr22",26725000,26730000,"rgba(255, 85, 0, 0.8)"],["chr22",26760000,26770000,"chr22",27040000,27050000,"rgba(255, 85, 0, 0.8)"],["chr22",26795000,26800000,"chr22",26855000,26860000,"rgba(255, 85, 0, 0.8)"],["chr22",26890000,26900000,"chr22",27040000,27050000,"rgba(255, 85, 0, 0.8)"],["chr22",27150000,27160000,"chr22",28400000,28410000,"rgba(255, 85, 0, 0.8)"],["chr22",28280000,28285000,"chr22",28405000,28410000,"rgba(255, 85, 0, 0.8)"],["chr22",28410000,28420000,"chr22",29220000,29230000,"rgba(255, 85, 0, 0.8)"],["chr22",28415000,28420000,"chr22",28985000,28990000,"rgba(255, 85, 0, 0.8)"],["chr22",28995000,29000000,"chr22",29225000,29230000,"rgba(255, 85, 0, 0.8)"],["chr22",28995000,29000000,"chr22",29435000,29440000,"rgba(255, 85, 0, 0.8)"],["chr22",28995000,29000000,"chr22",29640000,29645000,"rgba(255, 85, 0, 0.8)"],["chr22",29250000,29255000,"chr22",29435000,29440000,"rgba(255, 85, 0, 0.8)"],["chr22",29250000,29255000,"chr22",29640000,29645000,"rgba(255, 85, 0, 0.8)"],["chr22",29560000,29565000,"chr22",29595000,29600000,"rgba(255, 85, 0, 0.8)"],["chr22",29560000,29565000,"chr22",29640000,29645000,"rgba(255, 85, 0, 0.8)"],["chr22",29780000,29790000,"chr22",30480000,30490000,"rgba(255, 85, 0, 0.8)"],["chr22",29790000,29795000,"chr22",29920000,29925000,"rgba(255, 85, 0, 0.8)"],["chr22",30030000,30035000,"chr22",30400000,30405000,"rgba(255, 85, 0, 0.8)"],["chr22",30030000,30035000,"chr22",30480000,30485000,"rgba(255, 85, 0, 0.8)"],["chr22",30500000,30505000,"chr22",30655000,30660000,"rgba(255, 85, 0, 0.8)"],["chr22",30500000,30505000,"chr22",30680000,30685000,"rgba(255, 85, 0, 0.8)"],["chr22",30500000,30505000,"chr22",30785000,30790000,"rgba(255, 85, 0, 0.8)"],["chr22",30680000,30685000,"chr22",30785000,30790000,"rgba(255, 85, 0, 0.8)"],["chr22",30785000,30790000,"chr22",30875000,30880000,"rgba(255, 85, 0, 0.8)"],["chr22",30840000,30845000,"chr22",30875000,30880000,"rgba(255, 85, 0, 0.8)"],["chr22",31030000,31035000,"chr22",31150000,31155000,"rgba(255, 85, 0, 0.8)"],["chr22",31030000,31035000,"chr22",31315000,31320000,"rgba(255, 85, 0, 0.8)"],["chr22",31485000,31490000,"chr22",31625000,31630000,"rgba(255, 85, 0, 0.8)"],["chr22",31950000,31955000,"chr22",32025000,32030000,"rgba(255, 85, 0, 0.8)"],["chr22",32060000,32065000,"chr22",32340000,32345000,"rgba(255, 85, 0, 0.8)"],["chr22",32060000,32070000,"chr22",32470000,32480000,"rgba(255, 85, 0, 0.8)"],["chr22",32140000,32150000,"chr22",32340000,32350000,"rgba(255, 85, 0, 0.8)"],["chr22",32370000,32375000,"chr22",32470000,32475000,"rgba(255, 85, 0, 0.8)"],["chr22",32920000,32925000,"chr22",33020000,33025000,"rgba(255, 85, 0, 0.8)"],["chr22",32920000,32925000,"chr22",33190000,33195000,"rgba(255, 85, 0, 0.8)"],["chr22",32920000,32925000,"chr22",33380000,33385000,"rgba(255, 85, 0, 0.8)"],["chr22",33410000,33415000,"chr22",33595000,33600000,"rgba(255, 85, 0, 0.8)"],["chr22",33690000,33700000,"chr22",35520000,35530000,"rgba(255, 85, 0, 0.8)"],["chr22",33700000,33705000,"chr22",33910000,33915000,"rgba(255, 85, 0, 0.8)"],["chr22",33700000,33705000,"chr22",33970000,33975000,"rgba(255, 85, 0, 0.8)"],["chr22",33700000,33705000,"chr22",34310000,34315000,"rgba(255, 85, 0, 0.8)"],["chr22",33700000,33705000,"chr22",34485000,34490000,"rgba(255, 85, 0, 0.8)"],["chr22",33860000,33870000,"chr22",35520000,35530000,"rgba(255, 85, 0, 0.8)"],["chr22",33910000,33915000,"chr22",34310000,34315000,"rgba(255, 85, 0, 0.8)"],["chr22",33910000,33915000,"chr22",34505000,34510000,"rgba(255, 85, 0, 0.8)"],["chr22",33915000,33920000,"chr22",33970000,33975000,"rgba(255, 85, 0, 0.8)"],["chr22",34320000,34325000,"chr22",34500000,34505000,"rgba(255, 85, 0, 0.8)"],["chr22",34320000,34330000,"chr22",35540000,35550000,"rgba(255, 85, 0, 0.8)"],["chr22",34810000,34820000,"chr22",35410000,35420000,"rgba(255, 85, 0, 0.8)"],["chr22",34810000,34820000,"chr22",35540000,35550000,"rgba(255, 85, 0, 0.8)"],["chr22",35440000,35445000,"chr22",35535000,35540000,"rgba(255, 85, 0, 0.8)"],["chr22",35740000,35750000,"chr22",36510000,36520000,"rgba(255, 85, 0, 0.8)"],["chr22",35745000,35750000,"chr22",35980000,35985000,"rgba(255, 85, 0, 0.8)"],["chr22",35745000,35750000,"chr22",36015000,36020000,"rgba(255, 85, 0, 0.8)"],["chr22",35750000,35760000,"chr22",36310000,36320000,"rgba(255, 85, 0, 0.8)"],["chr22",36025000,36030000,"chr22",36520000,36525000,"rgba(255, 85, 0, 0.8)"],["chr22",36320000,36325000,"chr22",36515000,36520000,"rgba(255, 85, 0, 0.8)"],["chr22",36535000,36540000,"chr22",36575000,36580000,"rgba(255, 85, 0, 0.8)"],["chr22",36690000,36695000,"chr22",36860000,36865000,"rgba(255, 85, 0, 0.8)"],["chr22",36940000,36950000,"chr22",37370000,37380000,"rgba(255, 85, 0, 0.8)"],["chr22",37170000,37180000,"chr22",37590000,37600000,"rgba(255, 85, 0, 0.8)"],["chr22",37175000,37180000,"chr22",37250000,37255000,"rgba(255, 85, 0, 0.8)"],["chr22",37180000,37185000,"chr22",37375000,37380000,"rgba(255, 85, 0, 0.8)"],["chr22",37250000,37260000,"chr22",37370000,37380000,"rgba(255, 85, 0, 0.8)"],["chr22",37250000,37260000,"chr22",37610000,37620000,"rgba(255, 85, 0, 0.8)"],["chr22",37260000,37265000,"chr22",37295000,37300000,"rgba(255, 85, 0, 0.8)"],["chr22",37475000,37480000,"chr22",37580000,37585000,"rgba(255, 85, 0, 0.8)"],["chr22",37660000,37665000,"chr22",37850000,37855000,"rgba(255, 85, 0, 0.8)"],["chr22",37710000,37715000,"chr22",37850000,37855000,"rgba(255, 85, 0, 0.8)"],["chr22",38020000,38025000,"chr22",38075000,38080000,"rgba(255, 85, 0, 0.8)"],["chr22",38210000,38215000,"chr22",38255000,38260000,"rgba(255, 85, 0, 0.8)"],["chr22",38210000,38215000,"chr22",38355000,38360000,"rgba(255, 85, 0, 0.8)"],["chr22",39160000,39170000,"chr22",39520000,39530000,"rgba(255, 85, 0, 0.8)"],["chr22",39265000,39270000,"chr22",39395000,39400000,"rgba(255, 85, 0, 0.8)"],["chr22",39265000,39270000,"chr22",39510000,39515000,"rgba(255, 85, 0, 0.8)"],["chr22",39265000,39270000,"chr22",39545000,39550000,"rgba(255, 85, 0, 0.8)"],["chr22",39400000,39405000,"chr22",39710000,39715000,"rgba(255, 85, 0, 0.8)"],["chr22",39405000,39410000,"chr22",39510000,39515000,"rgba(255, 85, 0, 0.8)"],["chr22",39565000,39570000,"chr22",39705000,39710000,"rgba(255, 85, 0, 0.8)"],["chr22",39565000,39570000,"chr22",39915000,39920000,"rgba(255, 85, 0, 0.8)"],["chr22",39930000,39935000,"chr22",40430000,40435000,"rgba(255, 85, 0, 0.8)"],["chr22",39930000,39935000,"chr22",40740000,40745000,"rgba(255, 85, 0, 0.8)"],["chr22",40440000,40450000,"chr22",40740000,40750000,"rgba(255, 85, 0, 0.8)"],["chr22",40830000,40835000,"chr22",41040000,41045000,"rgba(255, 85, 0, 0.8)"],["chr22",40910000,40920000,"chr22",41290000,41300000,"rgba(255, 85, 0, 0.8)"],["chr22",40920000,40925000,"chr22",41040000,41045000,"rgba(255, 85, 0, 0.8)"],["chr22",41070000,41080000,"chr22",41290000,41300000,"rgba(255, 85, 0, 0.8)"],["chr22",41345000,41350000,"chr22",41480000,41485000,"rgba(255, 85, 0, 0.8)"],["chr22",41800000,41805000,"chr22",41910000,41915000,"rgba(255, 85, 0, 0.8)"],["chr22",42090000,42095000,"chr22",42335000,42340000,"rgba(255, 85, 0, 0.8)"],["chr22",42220000,42225000,"chr22",42335000,42340000,"rgba(255, 85, 0, 0.8)"],["chr22",42565000,42570000,"chr22",42830000,42835000,"rgba(255, 85, 0, 0.8)"],["chr22",43015000,43020000,"chr22",43050000,43055000,"rgba(255, 85, 0, 0.8)"],["chr22",43055000,43060000,"chr22",43160000,43165000,"rgba(255, 85, 0, 0.8)"],["chr22",43625000,43630000,"chr22",43740000,43745000,"rgba(255, 85, 0, 0.8)"],["chr22",43670000,43675000,"chr22",43740000,43745000,"rgba(255, 85, 0, 0.8)"],["chr22",43670000,43675000,"chr22",43775000,43780000,"rgba(255, 85, 0, 0.8)"],["chr22",43780000,43790000,"chr22",45020000,45030000,"rgba(255, 85, 0, 0.8)"],["chr22",44390000,44395000,"chr22",44480000,44485000,"rgba(255, 85, 0, 0.8)"],["chr22",44390000,44395000,"chr22",45020000,45025000,"rgba(255, 85, 0, 0.8)"],["chr22",44480000,44485000,"chr22",45020000,45025000,"rgba(255, 85, 0, 0.8)"],["chr22",45090000,45095000,"chr22",45130000,45135000,"rgba(255, 85, 0, 0.8)"],["chr22",45215000,45220000,"chr22",45490000,45495000,"rgba(255, 85, 0, 0.8)"],["chr22",45665000,45670000,"chr22",45830000,45835000,"rgba(255, 85, 0, 0.8)"],["chr22",45665000,45670000,"chr22",45945000,45950000,"rgba(255, 85, 0, 0.8)"],["chr22",46010000,46015000,"chr22",47985000,47990000,"rgba(255, 85, 0, 0.8)"],["chr22",46040000,46045000,"chr22",46375000,46380000,"rgba(255, 85, 0, 0.8)"],["chr22",46405000,46410000,"chr22",46510000,46515000,"rgba(255, 85, 0, 0.8)"],["chr22",46510000,46520000,"chr22",46700000,46710000,"rgba(255, 85, 0, 0.8)"],["chr22",46510000,46520000,"chr22",46940000,46950000,"rgba(255, 85, 0, 0.8)"],["chr22",46755000,46760000,"chr22",46935000,46940000,"rgba(255, 85, 0, 0.8)"],["chr22",47610000,47620000,"chr22",48880000,48890000,"rgba(255, 85, 0, 0.8)"],["chr22",50160000,50165000,"chr22",50315000,50320000,"rgba(255, 85, 0, 0.8)"],["chr22",50160000,50165000,"chr22",50465000,50470000,"rgba(255, 85, 0, 0.8)"],["chr22",50160000,50165000,"chr22",50650000,50655000,"rgba(255, 85, 0, 0.8)"],["chr22",50325000,50330000,"chr22",50465000,50470000,"rgba(255, 85, 0, 0.8)"],["chr22",50585000,50590000,"chr22",50650000,50655000,"rgba(255, 85, 0, 0.8)"],["chr22",50690000,50695000,"chr22",50935000,50940000,"rgba(255, 85, 0, 0.8)","green"],["chr22",50710000,50715000,"chr22",50760000,50765000,"rgba(255, 85, 0, 0.33)","rgba(0, 0, 0, 0.8)"]]}}],"right":[],"bottom":[]},"layout":{"w":12,"h":12,"x":0,"y":0,"i":"aa","moved":false,"static":false}}],"zoomLocks":{"locksByViewUid":{},"zoomLocksDict":{}}}
+
+    window.higlassApi;
+
+    hglib.createHgComponent(
+        document.getElementById('development-demo'),
+        testconfig2,
+        { bounded: true },
+        function (api) {
+            window.higlassApi = api;
+        }
+    );
+
+    function addSelectionView (hgConfig) {
+    var originalView = hgConfig.views[0];
+
+    ////////////////////////////////////////////////////////////////////////////
+    // The omission of the following line causes the crash
+    ////////////////////////////////////////////////////////////////////////////
+    // originalView.uid += '_';
+
+    // Adjust height of the original view
+    originalView.layout.h = 6;
+
+    var selectionView = JSON.parse(JSON.stringify(originalView));
+
+    selectionView.uid = '_' + selectionView.layout.i;
+    selectionView.zoomFixed = false;
+    selectionView.layout.y = 6;
+    selectionView.layout.i = selectionView.uid;
+
+    // Prefix all `uid`s with an underscore
+    Object.keys(selectionView.tracks).forEach((trackType) => {
+      selectionView.tracks[trackType].forEach((track) => {
+        track.uid = '_' + track.uid;
+        if (track.contents) {
+          track.contents.forEach((content) => {
+            content.uid = '_' + content.uid;
+          });
+        }
+      });
+    });
+
+    // Add view projection view
+    originalView.tracks.center.push({
+      uid: 'viewport-projection-center',
+      type: 'viewport-projection-center',
+      fromViewUid: selectionView.uid,
+      options: {},
+      name: 'Viewport Projection'
+    });
+
+    // Add selection view
+    hgConfig.views.push(selectionView);
+  }
+
+
+    var testconfig3 = JSON.parse(JSON.stringify(testconfig2));
+
+    addSelectionView(testconfig3);
+
+    setTimeout(function () {
+      hglib.createHgComponent(
+          document.getElementById('development-demo'),
+          testconfig3,
+          { bounded: true },
+          function (api) {
+              window.higlassApi = api;
+          }
+      );
+    }, 7500);
+
+
+</script>
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+          })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-77756807-1', 'auto');
+    ga('send', 'pageview');
+
+</script>
+</html>

--- a/app/scripts/TrackRenderer.jsx
+++ b/app/scripts/TrackRenderer.jsx
@@ -134,24 +134,34 @@ export class TrackRenderer extends React.Component {
     }
 
     setUpInitialScales(initialXDomain, initialYDomain) {
-        // make sure the two scales are equally wide:
-        let xWidth = initialXDomain[1] - initialXDomain[0];
-        let yCenter = (initialYDomain[0] + initialYDomain[1]) / 2;
-        //initialYDomain = [yCenter - xWidth / 2, yCenter + xWidth / 2];
+        // Test which side is longer
+        const portait = this.currentProps.centerHeight > this.currentProps.centerWidth;
 
-        // stretch out the y-scale so that views aren't distorted (i.e. maintain
-        // a 1 to 1 ratio)
-        initialYDomain[0] = yCenter - xWidth / 2, 
-        initialYDomain[1] = yCenter + xWidth / 2;
+        // Fritz: Not sure if the code below is actually needed. It worked for me without it.
+        // if (portait) {
+        //     // make sure the two scales are equally wide:
+        //     const xWidth = initialXDomain[1] - initialXDomain[0];
+        //     const yCenter = (initialYDomain[0] + initialYDomain[1]) / 2;
+        //     //initialYDomain = [yCenter - xWidth / 2, yCenter + xWidth / 2];
+
+        //     // stretch out the y-scale so that views aren't distorted (i.e. maintain
+        //     // a 1 to 1 ratio)
+        //     initialYDomain[0] = yCenter - xWidth / 2,
+        //     initialYDomain[1] = yCenter + xWidth / 2;
+        // } else {
+        //     const yWidth = initialYDomain[1] - initialYDomain[0];
+        //     const xCenter = (initialXDomain[0] + initialXDomain[1]) / 2;
+
+        //     initialXDomain[0] = xCenter - yWidth / 2,
+        //     initialXDomain[1] = xCenter + yWidth / 2;
+        // }
 
         if (initialXDomain == this.initialXDomain &&
             initialYDomain == this.initialYDomain)
-        /*
-        if (initialXDomain[0] == this.initialXDomain[0] &&
-            initialXDomain[1] == this.initialXDomain[1] &&
-            initialYDomain[1] == this.initialYDomain[1] &&
-            initialYDomain[0] == this.initialYDomain[0])
-            */
+        // if (initialXDomain[0] == this.initialXDomain[0] &&
+        //     initialXDomain[1] == this.initialXDomain[1] &&
+        //     initialYDomain[1] == this.initialYDomain[1] &&
+        //     initialYDomain[0] == this.initialYDomain[0])
             return;
 
         // only update the initial domain
@@ -161,17 +171,24 @@ export class TrackRenderer extends React.Component {
         this.cumCenterYOffset = 0;
         this.cumCenterXOffset = 0;
 
+        // Determine domain size depending on the view's dimensions (portrait or landscape)
+        const drawableDomainXStart = portait ? 0 : this.currentProps.centerWidth / 2 - this.currentProps.centerHeight / 2;
+        const drawableDomainXEnd = portait ? this.currentProps.centerWidth : this.currentProps.centerWidth / 2 + this.currentProps.centerHeight / 2;
+        const drawableDomainYStart = !portait ? 0 : this.currentProps.centerHeight / 2 - this.currentProps.centerWidth / 2;
+        const drawableDomainYEnd = !portait ? this.currentProps.centerHeight : this.currentProps.centerHeight / 2 + this.currentProps.centerWidth / 2;
+
         this.drawableToDomainX = scaleLinear()
-            .domain([this.currentProps.marginLeft + this.currentProps.leftWidth,
-                    this.currentProps.marginLeft + this.currentProps.leftWidth + this.currentProps.centerWidth])
+            .domain([
+                this.currentProps.marginLeft + this.currentProps.leftWidth + drawableDomainXStart,
+                this.currentProps.marginLeft + this.currentProps.leftWidth + drawableDomainXEnd
+            ])
             .range([initialXDomain[0], initialXDomain[1]]);
 
-        let midXDomain = (initialXDomain[0] + initialXDomain[0]) / 2;
-        let yDomainWidth = (initialXDomain[1] - initialXDomain[0]) * (this.currentProps.centerHeight / this.currentProps.centerWidth);
-
         this.drawableToDomainY = scaleLinear()
-            .domain([this.currentProps.marginTop + this.currentProps.topHeight + this.currentProps.centerHeight / 2 - this.currentProps.centerWidth / 2,
-                    this.currentProps.marginTop + this.currentProps.topHeight + this.currentProps.centerHeight / 2 + this.currentProps.centerWidth / 2])
+            .domain([
+                this.currentProps.marginTop + this.currentProps.topHeight + drawableDomainYStart,
+                this.currentProps.marginTop + this.currentProps.topHeight + drawableDomainYEnd
+            ])
             .range([initialYDomain[0], initialYDomain[1]]);
     }
 


### PR DESCRIPTION
Make sure the initial domains are fully visible independent of the view dimensions (portrait or landscape).

Also added an example for the domain bug when programmatically adding a view with a view port projection