### PR TITLE
Flekschas/convenient hgc function

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+v0.10.7 (2018-01-??)
+
+- Simplified `hglib` api
+- Updated third-party libs to get rid of deprecation warnings for React v16
+
 v0.10.6 (2017-12-28)
 
 - Load ResizeSensors after the element is attached to the DOM tree

--- a/app/api.html
+++ b/app/api.html
@@ -11,10 +11,10 @@
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/latest/css/bootstrap.min.css">
 <link rel="stylesheet" href="styles/page.css">
 <link rel="stylesheet" href="hglib.css">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.5.4/react.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.5.4/react-dom.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/4.5.2/pixi.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/react-bootstrap/0.31.0/react-bootstrap.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.6.2/react.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/15.6.2/react-dom.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/4.6.2/pixi.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/react-bootstrap/0.32.0/react-bootstrap.js"></script>
 </head>
 <body >
   <div style="height: 50px" />
@@ -137,7 +137,7 @@ const testViewConfig = {
         2343023255.8139534
       ],
       layout: {
-        w: 6,
+        w: 12,
         h: 12,
         x: 0,
         y: 0,
@@ -157,16 +157,13 @@ const testViewConfig = {
   }
 };
 
-let higlassApi;
-
-window.hglib.createHgComponent(
+const higlass = window.hglib.viewer(
   document.getElementById('development-demo'),
-  testViewConfig,
-  { bounded: true },
-  (api) => { higlassApi = api; }
+  'http://higlass.io/api/v1/viewconfs/?d=default',
+  { bounded: true }
 );
 
-higlassApi.on('location', (yeahCool) => {
+higlass.on('location', (yeahCool) => {
   console.log('Yuuhuu we are over here', yeahCool);
 }, 'aa', (id) => {
   console.log('First Listener ID', id);
@@ -174,7 +171,7 @@ higlassApi.on('location', (yeahCool) => {
 
 let secondId;
 
-higlassApi.on('location', (yeahCool) => {
+higlass.on('location', (yeahCool) => {
   console.log('Dont forget about us sweetie', yeahCool);
 }, 'aa', (id) => {
   secondId = id;
@@ -182,9 +179,14 @@ higlassApi.on('location', (yeahCool) => {
 });
 
 setTimeout(() => {
-  higlassApi.off('location', secondId, 'aa');
+  higlass.off('location', secondId, 'aa');
   console.log('Second event listener is offline');
 }, 5000);
+
+let prevViewConfig;
+higlass.on('viewConfig', (newViewConfig) => {
+  console.log('And here it is: a new view config! YEAH!', prevViewConfig === newViewConfig);
+});
 
 </script>
 </html>

--- a/app/dev.html
+++ b/app/dev.html
@@ -11,10 +11,10 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/latest/css/bootstrap.min.css">
     <link rel="stylesheet" href="styles/page.css">
     <link rel="stylesheet" href="hglib.css">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.5.4/react.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.5.4/react-dom.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/4.5.2/pixi.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/react-bootstrap/0.31.0/react-bootstrap.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.6.2/react.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/15.6.2/react-dom.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/4.6.2/pixi.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/react-bootstrap/0.32.0/react-bootstrap.js"></script>
 </head>
 <body >
     <div style="height: 50px" />
@@ -280,22 +280,17 @@
 }
  ;
 
-    window.higlassApi;
-
-    hglib.createHgComponent(
+    hgApi = hglib.viewer(
         document.getElementById('development-demo'),
         testViewConfig,
         { bounded: true },
-        function (api) {
-            window.hgApi = api;
-        }
     );
 
-    window.hgApi.on('viewConfig', function (viewConfig) {
+    hgApi.on('viewConfig', function (viewConfig) {
       console.log('View Config changed');
     });
 
-    window.hgApi.on('rangeSelection', function (rangeSelection) {
+    hgApi.on('rangeSelection', function (rangeSelection) {
       console.log(
         'Selected the following range:',
         rangeSelection[0],
@@ -303,15 +298,15 @@
       );
     });
 
-    window.hgApi.get('yes')
+    hgApi.get('yes')
       .then(() => console.log('yes!'))
       .catch(() => console.warn('no!'));
 
-    window.hgApi.get('location')
+    hgApi.get('location')
       .then((loc) => console.log('Location', loc))
       .catch((e) => console.warn('No location!', e));
 
-    window.hgApi.get('viewConfig')
+    hgApi.get('viewConfig')
       .then((viewConfig) => {
         var vc = JSON.parse(viewConfig);
         console.log('viewConfig', vc);

--- a/app/index.html
+++ b/app/index.html
@@ -11,9 +11,9 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/latest/css/bootstrap.min.css">
     <link rel="stylesheet" href="styles/page.css">
     <link rel="stylesheet" href="hglib.css">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.5.4/react.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.5.4/react-dom.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/4.5.2/pixi.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.6.2/react.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/15.6.2/react-dom.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/4.6.2/pixi.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/react-bootstrap/0.31.0/react-bootstrap.min.js"></script>
 </head>
 <body >
@@ -369,15 +369,10 @@
 }
  ;
 
-    window.higlassApi;
-
-    hglib.createHgComponent(
+    window.hgApi = hglib.viewer(
         document.getElementById('development-demo'),
         testViewConfig,
         { bounded: true },
-        function (api) {
-            window.hgApi = api;
-        }
     );
 
     window.hgApi.on('view', function (viewConfig) {

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { select } from 'd3-selection';
 import { scaleLinear } from 'd3-scale';
-import { request } from 'd3-request';
+import { json, request } from 'd3-request';
 import slugid from 'slugid';
 import ReactDOM from 'react-dom';
 import ReactGridLayout from 'react-grid-layout';
@@ -32,7 +32,7 @@ import {
   download,
   getTrackByUid,
   getTrackPositionByUid,
-  loadChromInfos,
+  // loadChromInfos,
   objVals,
   positionedTracksToAllTracks,
   scalesCenterAndK,
@@ -114,13 +114,33 @@ class HiGlassComponent extends React.Component {
 
     this.boundRefreshView = (() => { this.refreshView(LONG_DRAG_TIMEOUT); });
 
-    this.viewConfig = this.props.viewConfig;
+    this.unsetOnLocationChange = [];
+
+    let viewConfig = {};
+    let views = {};
+    if (typeof this.props.viewConfig === 'string') {
+      // Load external viewConfig
+      json(this.props.viewConfig, (error, viewConfig) => {
+        this.setState({
+          viewConfig,
+          views: this.processViewConfig(
+            JSON.parse(JSON.stringify(viewConfig))
+          )
+        });
+        this.unsetOnLocationChange.forEach(({ viewId, callback, callbackId }) => {
+          this.onLocationChange(viewId, callback, callbackId);
+        });
+      });
+    } else {
+      viewConfig = this.props.viewConfig;
+      views = this.processViewConfig(
+        JSON.parse(JSON.stringify(viewConfig))
+      );
+    }
 
     this.pixiStage = new PIXI.Container();
     this.pixiStage.interactive = true;
     this.element = null;
-
-    const viewsByUid = this.processViewConfig(JSON.parse(JSON.stringify(this.props.viewConfig)));
 
     let mouseTool = MOUSE_TOOL_MOVE;
 
@@ -141,7 +161,8 @@ class HiGlassComponent extends React.Component {
       rowHeight: 30,
       svgElement: null,
       canvasElement: null,
-      views: viewsByUid,
+      views,
+      viewConfig,
       addTrackPositionMenuPosition: null,
 
       // chooseViewHandler: uid2 => this.handleZoomYanked(views[0].uid, uid2),
@@ -154,7 +175,7 @@ class HiGlassComponent extends React.Component {
       mouseTool,
     };
 
-    dictValues(viewsByUid).map(view => this.adjustLayoutToTrackSizes(view));
+    dictValues(views).map(view => this.adjustLayoutToTrackSizes(view));
 
     // monitor whether this element is attached to the DOM so that
     // we can determine whether to add the resizesensor
@@ -194,15 +215,10 @@ class HiGlassComponent extends React.Component {
     this.pubSubs.push(
       pubSub.subscribe('orientationchange', this.resizeHandler.bind(this)),
     );
-
-    if (this.props.getApi) {
-      this.props.getApi(this.api);
-    }
   }
 
   waitForDOMAttachment(callback) {
-    if (!this.mounted)
-      return;
+    if (!this.mounted) return;
 
     const thisElement = ReactDOM.findDOMNode(this);
 
@@ -1128,7 +1144,7 @@ class HiGlassComponent extends React.Component {
     this.handleDragStart();
     this.handleDragStop();
 
-    const MARGIN_HEIGHT = this.props.viewConfig.editable ? 10 : 0;
+    const MARGIN_HEIGHT = this.state.viewConfig.editable ? 10 : 0;
 
     const marginHeight = (MARGIN_HEIGHT * maxHeight) - 1;
     const availableHeight = height - marginHeight;
@@ -1774,7 +1790,7 @@ class HiGlassComponent extends React.Component {
 
     // we are not checking for this.viewHeaders because this function may be
     // called before the component is mounted
-    if (this.props.viewConfig.editable) {
+    if (this.state.viewConfig.editable) {
       totalTrackHeight += VIEW_HEADER_HEIGHT;
     }
 
@@ -1783,7 +1799,7 @@ class HiGlassComponent extends React.Component {
     const { totalHeight } = this.calculateViewDimensions(view);
     totalTrackHeight += totalHeight;
 
-    const MARGIN_HEIGHT = this.props.viewConfig.editable ? 10 : 0;
+    const MARGIN_HEIGHT = this.state.viewConfig.editable ? 10 : 0;
 
     if (!this.props.options.bounded) {
       view.layout.h = Math.ceil(
@@ -2014,7 +2030,7 @@ class HiGlassComponent extends React.Component {
   }
 
   getViewsAsString() {
-    const newJson = JSON.parse(JSON.stringify(this.props.viewConfig));
+    const newJson = JSON.parse(JSON.stringify(this.state.viewConfig));
     newJson.views = dictItems(this.state.views).map((k) => {
       const newView = JSON.parse(JSON.stringify(k[1]));
       const uid = k[0];
@@ -2067,7 +2083,7 @@ class HiGlassComponent extends React.Component {
       exportLinkLocation: null,
     });
 
-    request(this.props.viewConfig.exportViewUrl)
+    request(this.state.viewConfig.exportViewUrl)
       .header('X-Requested-With', 'XMLHttpRequest')
       .header('Content-Type', 'application/json')
       .post(wrapper, (error, response) => {
@@ -2075,7 +2091,7 @@ class HiGlassComponent extends React.Component {
           const content = JSON.parse(response.response);
           const portString = window.location.port === '' ? '' : `:${window.location.port}`;
           this.setState({
-            // exportLinkLocation: this.props.viewConfig.exportViewUrl + "?d=" + content.uid
+            // exportLinkLocation: this.state.viewConfig.exportViewUrl + "?d=" + content.uid
             exportLinkLocation: `http://${window.location.hostname}${portString}/app/?config=${content.uid}`,
           });
         } else {
@@ -2561,10 +2577,20 @@ class HiGlassComponent extends React.Component {
     this.removeScalesChangedListener(viewId, listenerId);
   }
 
-onLocationChange(viewId, callback, callbackId) {
+  onLocationChange(viewId, callback, callbackId) {
+    const viewsIds = Object.keys(this.state.views);
+
+    if (!viewsIds.length) {
+      // HiGlass was probably initialized with an URL instead of a viewconfig
+      // and that remote viewConfig is not yet loaded.
+      this.unsetOnLocationChange.push({
+        viewId, callback, callbackId
+      });
+      return;
+    }
+
     if (
-      typeof viewId === 'undefined' ||
-      Object.keys(this.state.views).indexOf(viewId) === -1
+      typeof viewId === 'undefined' || viewsIds.indexOf(viewId) === -1
     ) {
       console.error(
         '🦄 listen to me: you forgot to give me a propper view ID. ' +
@@ -2679,7 +2705,7 @@ onLocationChange(viewId, callback, callbackId) {
                 null
             }
             chromInfoPath={view.chromInfoPath}
-            editable={this.props.viewConfig.editable}
+            editable={this.state.viewConfig.editable}
             horizontalMargin={this.horizontalMargin}
             initialXDomain={view.initialXDomain}
             initialYDomain={view.initialYDomain}
@@ -2717,7 +2743,7 @@ onLocationChange(viewId, callback, callbackId) {
             }
             setCentersFunction={(c) => { this.setCenters[view.uid] = c; }}
             svgElement={this.state.svgElement}
-            trackSourceServers={this.props.viewConfig.trackSourceServers}
+            trackSourceServers={this.state.viewConfig.trackSourceServers}
             tracks={view.tracks}
             uid={view.uid}
             verticalMargin={this.verticalMargin}
@@ -2752,13 +2778,13 @@ onLocationChange(viewId, callback, callbackId) {
                 this.removeScalesChangedListener(view.uid, view.uid)}
               setCenters={(centerX, centerY, k, animate, animateTime) =>
                 this.setCenters[view.uid](centerX, centerY, k, false, animate, animateTime)}
-              trackSourceServers={this.props.viewConfig.trackSourceServers}
+              trackSourceServers={this.state.viewConfig.trackSourceServers}
               twoD={true}
             />
           );
         };
 
-        const multiTrackHeader = this.props.viewConfig.editable && !this.props.viewConfig.hideHeader ? (
+        const multiTrackHeader = this.state.viewConfig.editable && !this.state.viewConfig.hideHeader ? (
           <ViewHeader
             // Reserved props
             ref={(c) => { this.viewHeaders[view.uid] = c; }}
@@ -2850,10 +2876,10 @@ onLocationChange(viewId, callback, callbackId) {
         cols={12}
         width={this.state.width}
         draggableHandle={`.${stylesMTHeader['multitrack-header-grabber']}`}
-        isDraggable={this.props.viewConfig.editable}
-        isResizable={this.props.viewConfig.editable}
+        isDraggable={this.state.viewConfig.editable}
+        isResizable={this.state.viewConfig.editable}
         layout={layouts}
-        margin={this.props.viewConfig.editable ? [10, 10] : [0, 0]}
+        margin={this.state.viewConfig.editable ? [10, 10] : [0, 0]}
         measureBeforeMount={false}
         onBreakpointChange={this.onBreakpointChange.bind(this)}
         onDragStart={this.handleDragStart.bind(this)}
@@ -2902,15 +2928,16 @@ onLocationChange(viewId, callback, callbackId) {
 }
 
 HiGlassComponent.defaultProps = {
-  getApi: null,
   options: {},
   zoomFixed: false,
 };
 
 HiGlassComponent.propTypes = {
-  getApi: PropTypes.func,
   options: PropTypes.object,
-  viewConfig: PropTypes.object.isRequired,
+  viewConfig: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+  ]).isRequired,
   zoomFixed: PropTypes.bool,
 };
 

--- a/app/scripts/hglib.js
+++ b/app/scripts/hglib.js
@@ -1,48 +1,56 @@
-import { json } from 'd3-request';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import HiGlassComponent from './HiGlassComponent';
 
 export { default as HiGlassComponent } from './HiGlassComponent';
 
-function launch(element, config, options, callback) {
+const launch = (element, config, options) => {
   /**
    * The instance's public API will be passed into the callback
    *
    * @param   {Object} higlass - HiGlass instance
    * @return  {Object} The instance's public API
    */
-  callback((function (higlass) {
-    return higlass.api;
-  }(
-    ReactDOM.render(
-      (<HiGlassComponent
-        options={options || {}}
-        viewConfig={config}
-      />),
-      element,
-    ),
-  )
-  ));
-}
+  let component;
+  ReactDOM.render(
+    <HiGlassComponent
+      ref={(c) => { component = c; }}
+      options={options || {}}
+      viewConfig={config}
+    />,
+    element,
+  );
+  return component;
+};
 
-export function createHgComponent(element, config, options, callback) {
+/**
+ * Create a HiGlass component
+ *
+ * @param  {Object}  element  DOM element the HiGlass component should be
+ *   associated to.
+ * @param  {Object|String}  viewConfig  Dictionary or URL of a view config.
+ * @param  {Object}  options  Dictionary of public options.
+ * @param  {Function}  callback  Callback function for the API.
+ * @return  {Object}  Newly created HiGlass component.
+ */
+export const createHgComponent = (element, viewConfig, options, callback) => {
   /**
    * Available options:
    *
    *  bounded: [true/false]
    *      Fit the container to the bounds of the element
    */
-  if (typeof config === 'string') {
-    // Load external config
-    json(config, (error, data) => {
-      if (error) throw error;
+  const hg = launch(element, viewConfig, options);
+  try {
+    console.warn(
+      'Deprecated use of `createHgComponent`. The api is directly returned ' +
+      'now.'
+    );
+    callback(hg.api);
+  } catch (e) { /* Nothing */ }
+  return hg.api;
+};
 
-      launch(element, data, options, callback);
-    });
-  } else {
-    launch(element, config, options, callback);
-  }
-}
+export const viewer = createHgComponent;
 
 export default createHgComponent;

--- a/app/test.html
+++ b/app/test.html
@@ -12,10 +12,10 @@
     <link rel="stylesheet" href="styles/page.css">
     <link rel="stylesheet" href="hglib.css">
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.5.4/react.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.5.4/react-dom.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/4.5.2/pixi.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-bootstrap/0.31.0/react-bootstrap.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.6.2/react.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/15.6.2/react-dom.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/4.6.2/pixi.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-bootstrap/0.32.0/react-bootstrap.min.js"></script>
 </head>
 <body >
     Here's some text
@@ -192,15 +192,10 @@
 }
 
 
-    window.higlassApi;
-
-    hglib.createHgComponent(
+    window.hgApi = hglib.viewer(
         document.getElementById('development-demo'),
         testViewConfig,
         { bounded: true },
-        function (api) {
-            window.hgApi = api;
-        }
     );
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2631,7 +2631,7 @@
       "dev": true
     },
     "css-element-queries": {
-      "version": "github:marcj/css-element-queries#072a3fc71c029f9a99dca469e272602982e6786c"
+      "version": "github:marcj/css-element-queries#2f6959de9c76dcd562ef8539dd40172ea76c1c2d"
     },
     "css-loader": {
       "version": "0.28.7",
@@ -11351,13 +11351,14 @@
       }
     },
     "react-sortable-hoc": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-0.1.1.tgz",
-      "integrity": "sha1-r7sbbo0axVr1QA3g1Mna14Iv+FI=",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-0.6.8.tgz",
+      "integrity": "sha512-sUUAtNdV84AKZ2o+F5lVOOFWcyWG6aGDkNFgHoieB1zFLeWLWENkix06asPS4/GhigfuRh06aZix1j3Qx8+NSQ==",
       "requires": {
         "babel-runtime": "6.26.0",
         "invariant": "2.2.2",
-        "lodash": "4.17.4"
+        "lodash": "4.17.4",
+        "prop-types": "15.5.10"
       }
     },
     "react-test-renderer": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "peerDependencies": {
     "pixi.js": "^4.6.2",
     "react": "^15.6.2",
-    "react-bootstrap": "^0.31.5",
+    "react-bootstrap": "^0.32.0",
     "react-dom": "^15.6.2"
   },
   "dependencies": {
@@ -61,7 +61,7 @@
     "react-dom": "^15.5.4",
     "react-grid-layout": "^0.16.0",
     "react-resizable": "^1.4.5",
-    "react-sortable-hoc": "^0.1.1",
+    "react-sortable-hoc": "^0.6.7",
     "reactcss": "^1.2.2",
     "slugid": "^1.1.0",
     "threads": "^0.7.2",


### PR DESCRIPTION
Implemented more convenient hglib (backwards compatible) interface.

Instead of

```
hglib.createHgComponent(
    document.getElementById('development-demo'),
    testViewConfig,
    { bounded: true },
    function (api) {
        window.hgApi = api;
    }
);
```

the public API of the newly created HiGlass component is now directly returned; i.e., 

```
hgApi = hglib.viewer(
    document.getElementById('development-demo'),
    testViewConfig,
    { bounded: true },
);
```

I've also updated react-bootstrap and react-sortable-hoc to get rid of deprecation warning for React `v16`.