### PR TITLE
Add translate and scale limits

### DIFF
--- a/app/restrict.html
+++ b/app/restrict.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>HiGlass</title>
+<style type="text/css">
+    .canvasjs-chart-credit {
+    display:none;
+}
+</style>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/latest/css/bootstrap.min.css">
+    <link rel="stylesheet" href="styles/page.css">
+    <link rel="stylesheet" href="hglib.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.6.2/react.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/15.6.2/react-dom.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/4.6.2/pixi.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/react-bootstrap/0.32.0/react-bootstrap.js"></script>
+</head>
+<body >
+    <div style="height: 50px" />
+        <div style="margin: auto; width: 100%;">
+        <div
+            id="development-demo"
+            style="position: absolute; left: 1rem; top: 1rem; bottom: 1rem; right: 1rem">
+        </div>
+    </div>
+</body>
+<script src='hglib.js'>
+</script>
+<script>
+
+const testViewConfig = {
+  editable: true,
+  zoomFixed: false,
+  trackSourceServers: [
+    'http://higlass.io/api/v1',
+    'http://localhost:8989/api/v1'
+  ],
+  exportViewUrl: 'http://localhost:8000/api/v1/viewconfs/',
+  views: [{
+    uid: 'aa1',
+    initialXDomain: [1000000000, 3000000000],
+    initialYDomain: [1000000000, 3000000000],
+    xDomainLimits: [1950914406, 1950914406 + 133851895],
+    yDomainLimits: [1950914406, 1950914406 + 133851895],
+    zoomLimits: [1, Infinity],
+    autocompleteSource: 'http://higlass.io/api/v1/suggest/?d=OHJakQICQD6gTD7skx4EWA&',
+    genomePositionSearchBox: {
+      autocompleteId: 'OHJakQICQD6gTD7skx4EWA',
+      autocompleteServer: 'http://higlass.io/api/v1',
+      chromInfoId: 'hg19',
+      chromInfoServer: 'http://higlass.io/api/v1',
+      visible: true
+    },
+    chromInfoPath: '//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv',
+    tracks: {
+      top: [{
+        uuid: 'OHJakQICQD6gTD7skx4EWA',
+        filetype: 'beddb',
+        datatype: 'gene-annotation',
+        private: false,
+        name: 'Gene Annotations (hg19)',
+        coordSystem: 'hg19',
+        coordSystem2: '',
+        server: 'http://higlass.io/api/v1',
+        tilesetUid: 'OHJakQICQD6gTD7skx4EWA',
+        serverUidKey: 'http://higlass.io/api/v1/OHJakQICQD6gTD7skx4EWA',
+        uid: 'BEEMEjU7QCa2krDO9C0yOQ',
+        type: 'horizontal-gene-annotations',
+        options: {
+          labelPosition: 'outerTop',
+          name: 'Gene Annotations (hg19)',
+          showMousePosition: true,
+          mousePositionColor: '#0000ff'
+        },
+        width: 20,
+        height: 60,
+        maxWidth: 4294967296,
+        maxZoom: 22
+      }, {
+        filetype: 'hitile',
+        datatype: 'vector',
+        private: false,
+        name: 'wgEncodeSydhTfbsGm12878Rad21IggrabSig.hitile',
+        coordSystem: 'hg19',
+        coordSystem2: '',
+        server: 'http://higlass.io/api/v1',
+        tilesetUid: 'F2vbUeqhS86XkxuO1j2rPA',
+        serverUidKey: 'http://higlass.io/api/v1/F2vbUeqhS86XkxuO1j2rPA',
+        type: 'horizontal-line',
+        options: {
+          labelColor: 'red',
+          labelPosition: 'outerLeft',
+          axisPositionHorizontal: 'right',
+          lineStrokeColor: 'blue',
+          name: 'wgEncodeSydhTfbsGm12878Rad21IggrabSig.hitile',
+          valueScaling: 'log',
+          showMousePosition: true,
+          mousePositionColor: '#0000ff'
+        },
+        width: 20,
+        height: 20,
+        maxWidth: 4294967296,
+        maxZoom: 22
+      }, {
+        chromInfoPath: '//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv',
+        type: 'horizontal-chromosome-labels',
+        position: 'top',
+        name: 'Chromosome Labels (hg19)',
+        height: 30,
+        uid: 'I1QUF22JQJuJ38j9PS4iqw',
+        options: {
+          showMousePosition: true,
+          mousePositionColor: '#0000ff'
+        }
+      }],
+      left: [{
+        name: 'wgEncodeSydhTfbsGm12878Rad21IggrabSig.hitile',
+        server: 'http://higlass.io/api/v1',
+        tilesetUid: 'F2vbUeqhS86XkxuO1j2rPA',
+        type: 'vertical-line',
+        options: {
+          labelColor: 'red',
+          labelPosition: 'outerLeft',
+          axisPositionHorizontal: 'right',
+          lineStrokeColor: 'blue',
+          name: 'wgEncodeSydhTfbsGm12878Rad21IggrabSig.hitile',
+          valueScaling: 'log',
+          showMousePosition: true,
+          mousePositionColor: '#0000ff'
+        }
+      },
+      {
+        type: 'vertical-gene-annotations',
+        width: 60,
+        tilesetUid: 'OHJakQICQD6gTD7skx4EWA',
+        server: 'http://higlass.io/api/v1',
+        position: 'left',
+        name: 'Gene Annotations (hg19)',
+        options: {
+          labelPosition: 'bottomRight',
+          name: 'Gene Annotations (hg19)',
+          showMousePosition: true,
+          mousePositionColor: '#0000ff'
+        },
+        uid: 'OgnAEKSHRaG-gR1RqPOuBQ',
+        maxWidth: 4294967296,
+        maxZoom: 22
+      },
+      {
+        chromInfoPath: '//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv',
+        type: 'vertical-chromosome-labels',
+        position: 'left',
+        name: 'Chromosome Labels (hg19)',
+        width: 30,
+        uid: 'a-mFiHnBQ8uuI6UG3USWVA',
+        options: {
+          showMousePosition: true,
+          mousePositionColor: '#0000ff'
+        }
+      }],
+      center: [{
+        uid: 'c1',
+        type: 'combined',
+        height: 200,
+        contents: [{
+          server: 'http://higlass.io/api/v1',
+          tilesetUid: 'CQMd6V_cRw6iCI_-Unl3PQ',
+          type: 'heatmap',
+          position: 'center',
+          options: {
+            colorRange: [
+              '#FFFFFF',
+              '#F8E71C',
+              '#F5A623',
+              '#D0021B'
+            ],
+            colorbarPosition: 'topRight',
+            colorbarLabelsPosition: 'outside',
+            maxZoom: null,
+            labelPosition: 'bottomLeft',
+            name: 'Rao et al. (2014) GM12878 MboI (allreps) 1kb',
+            showMousePosition: true,
+            mousePositionColor: '#0000ff'
+          },
+          uid: 'heatmap1',
+          name: 'Rao et al. (2014) GM12878 MboI (allreps) 1kb',
+          maxWidth: 4194304000,
+          binsPerDimension: 256,
+          maxZoom: 14
+        }, {
+          type: '2d-chromosome-grid',
+          datatype: [
+            'chromosome-2d-grid'
+          ],
+          local: true,
+          orientation: '2d',
+          name: 'Chromosome Grid (hg19)',
+          chromInfoPath: '//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv',
+          thumbnail: null,
+          uuid: 'TIlwFtqxTX-ndtM7Y9k1bw',
+          server: '',
+          tilesetUid: 'TIlwFtqxTX-ndtM7Y9k1bw',
+          serverUidKey: '/TIlwFtqxTX-ndtM7Y9k1bw',
+          uid: 'LUVqXXu2QYiO8XURIwyUyA',
+          options: {}
+        }],
+        position: 'center',
+        options: {}
+      }],
+      right: [{
+        type: 'vertical-gene-annotations',
+        width: 60,
+        tilesetUid: 'OHJakQICQD6gTD7skx4EWA',
+        server: 'http://higlass.io/api/v1',
+        name: 'Gene Annotations (hg19)',
+        options: {
+          labelPosition: 'outerBottom',
+          name: 'Gene Annotations (hg19)',
+          showMousePosition: true,
+          mousePositionColor: '#0000ff'
+        },
+        maxWidth: 4294967296,
+        maxZoom: 22
+      }, {
+        chromInfoPath: '//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv',
+        type: 'vertical-chromosome-labels',
+        name: 'Chromosome Labels (hg19)',
+        width: 30,
+        options: {
+          labelPosition: 'outerBottom',
+          name: 'Chromosome labels',
+          showMousePosition: true,
+          mousePositionColor: '#0000ff'
+        }
+      }],
+      bottom: [{
+        filetype: 'hitile',
+        datatype: 'vector',
+        private: false,
+        name: 'wgEncodeSydhTfbsGm12878Rad21IggrabSig.hitile',
+        coordSystem: 'hg19',
+        coordSystem2: '',
+        server: 'http://higlass.io/api/v1',
+        tilesetUid: 'F2vbUeqhS86XkxuO1j2rPA',
+        serverUidKey: 'http://higlass.io/api/v1/F2vbUeqhS86XkxuO1j2rPA',
+        type: 'horizontal-line',
+        options: {
+          labelPosition: 'outerLeft',
+          axisPositionHorizontal: 'right',
+          lineStrokeColor: 'blue',
+          name: 'wgEncodeSydhTfbsGm12878Rad21IggrabSig.hitile',
+          valueScaling: 'log',
+          showMousePosition: true,
+          mousePositionColor: '#0000ff'
+        },
+        width: 20,
+        height: 50,
+        maxWidth: 4294967296,
+        maxZoom: 22
+      }]
+    },
+    layout: {
+      w: 12,
+      h: 12,
+      x: 0,
+      y: 0,
+      i: 'aa',
+      moved: false,
+      static: false
+    }
+  }],
+  zoomLocks: {
+    locksByViewUid: {},
+    locksDict: {}
+  },
+  locationLocks: {
+    locksByViewUid: {},
+    locksDict: {}
+  }
+};
+
+window.hgApi = window.hglib.viewer(
+  document.getElementById('development-demo'),
+  testViewConfig,
+  { bounded: true },
+);
+
+</script>
+</html>

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -2899,6 +2899,9 @@ class HiGlassComponent extends React.Component {
             horizontalMargin={this.horizontalMargin}
             initialXDomain={view.initialXDomain}
             initialYDomain={view.initialYDomain}
+            xDomainLimits={view.xDomainLimits}
+            yDomainLimits={view.yDomainLimits}
+            zoomLimits={view.zoomLimits}
             mouseTool={this.state.mouseTool}
             onChangeTrackType={(trackId, newType) =>
               this.handleChangeTrackType(view.uid, trackId, newType)}

--- a/app/scripts/TiledPlot.js
+++ b/app/scripts/TiledPlot.js
@@ -1207,6 +1207,9 @@ export class TiledPlot extends React.Component {
           height={this.state.height}
           initialXDomain={this.props.initialXDomain}
           initialYDomain={this.props.initialYDomain}
+          xDomainLimits={this.props.xDomainLimits}
+          yDomainLimits={this.props.yDomainLimits}
+          zoomLimits={this.props.zoomLimits}
           isRangeSelection={this.props.mouseTool === MOUSE_TOOL_SELECT}
           leftWidth={this.leftWidth}
           marginLeft={this.props.horizontalMargin}

--- a/app/scripts/TrackRenderer.js
+++ b/app/scripts/TrackRenderer.js
@@ -120,16 +120,18 @@ export class TrackRenderer extends React.Component {
         if (event.target.classList.contains('react-resizable-handle')) { return false; }
         return true;
       })
-      // Limit max zoomout level to 0.25
-      // .scaleExtent([0.25, Infinity])
-      // Define translate extend
-      // .translateExtent([[-2000, -2000], [2000, 2000]])
       .on('start', this.zoomStartedBound)
       .on('zoom', this.zoomedBound)
       .on('end', this.zoomEndedBound);
 
+    this.zoomTransform = zoomIdentity;
+    this.prevZoomTransform = zoomIdentity;
+
     this.initialXDomain = [0, 1];
     this.initialYDomain = [0, 1];
+    this.xDomainLimits = [-Infinity, Infinity];
+    this.yDomainLimits = [-Infinity, Infinity];
+    this.zoomLimits = [0, Infinity];
 
     this.prevCenterX = (
       this.currentProps.marginLeft +
@@ -149,6 +151,9 @@ export class TrackRenderer extends React.Component {
     this.setUpInitialScales(
       this.currentProps.initialXDomain,
       this.currentProps.initialYDomain,
+      this.currentProps.xDomainLimits,
+      this.currentProps.yDomainLimits,
+      this.currentProps.zoomLimits,
     );
 
     this.setUpScales();
@@ -232,6 +237,9 @@ export class TrackRenderer extends React.Component {
     this.setUpInitialScales(
       nextProps.initialXDomain,
       nextProps.initialYDomain,
+      nextProps.xDomainLimits,
+      nextProps.yDomainLimits,
+      nextProps.zoomLimits,
     );
 
     this.setUpScales(
@@ -241,6 +249,27 @@ export class TrackRenderer extends React.Component {
     this.canvasDom = ReactDOM.findDOMNode(nextProps.canvasElement);
 
     this.svgElement = nextProps.svgElement;
+
+    const transExt = [
+      [this.xScale(this.xDomainLimits[0]), this.yScale(this.yDomainLimits[0])],
+      [this.xScale(this.xDomainLimits[1]), this.yScale(this.yDomainLimits[1])]
+    ];
+
+    const svgBBox = this.svgElement.getBoundingClientRect();
+
+    const ext = [
+      [Math.max(transExt[0][0], 0), Math.max(transExt[0][1], 0)],
+      [Math.min(transExt[1][0], svgBBox.width), Math.min(transExt[1][1], svgBBox.height)],
+    ];
+
+    // if (this.scaleExtent) this.zoomBehavior.scaleExtent(this.zoomLimits);
+    // if (this.xDomainLimits) {
+    //   this.zoomBehavior.translateExtent(this.zoomLimits);
+    // }
+    this.zoomBehavior
+      .extent(ext)
+      .translateExtent(transExt)
+      .scaleExtent(this.zoomLimits);
 
     this.syncTrackObjects(nextProps.positionedTracks);
 
@@ -336,7 +365,17 @@ export class TrackRenderer extends React.Component {
     }, SCROLL_TIMEOUT);
   }
 
-  setUpInitialScales(initialXDomain = [0, 1], initialYDomain = [0, 1]) {
+  setUpInitialScales(
+    initialXDomain = [0, 1],
+    initialYDomain = [0, 1],
+    xDomainLimits = [-Infinity, Infinity],
+    yDomainLimits = [-Infinity, Infinity],
+    zoomLimits = [0, Infinity],
+  ) {
+    // Make sure the initial domain is within the limits first
+    zoomLimits[0] = zoomLimits[0] === null ? 0 : zoomLimits[0];
+    zoomLimits[1] = zoomLimits[1] === null ? Infinity : zoomLimits[1];
+
     // make sure the two scales are equally wide:
     const xWidth = initialXDomain[1] - initialXDomain[0];
     const yCenter = (initialYDomain[0] + initialYDomain[1]) / 2;
@@ -354,12 +393,21 @@ export class TrackRenderer extends React.Component {
       initialXDomain[0] === this.initialXDomain[0] &&
       initialXDomain[1] === this.initialXDomain[1] &&
       initialYDomain[0] === this.initialYDomain[0] &&
-      initialYDomain[1] === this.initialYDomain[1]
+      initialYDomain[1] === this.initialYDomain[1] &&
+      xDomainLimits[0] === this.xDomainLimits[0] &&
+      xDomainLimits[1] === this.xDomainLimits[1] &&
+      yDomainLimits[0] === this.yDomainLimits[0] &&
+      yDomainLimits[1] === this.yDomainLimits[1] &&
+      zoomLimits[0] === this.zoomLimits[0] &&
+      zoomLimits[1] === this.zoomLimits[1]
     ) return;
 
     // only update the initial domain
     this.initialXDomain = initialXDomain;
     this.initialYDomain = initialYDomain;
+    this.xDomainLimits = xDomainLimits;
+    this.yDomainLimits = yDomainLimits;
+    this.zoomLimits = zoomLimits;
 
     this.cumCenterYOffset = 0;
     this.cumCenterXOffset = 0;
@@ -762,15 +810,16 @@ export class TrackRenderer extends React.Component {
     return last;
   }
 
+  /**
+   * Respond to a zoom event.
+   *
+   * We need to update our local record of the zoom transform and apply it
+   * to all the tracks.
+   */
   zoomed() {
-    /**
-     * Respond to a zoom event.
-     *
-     * We need to update our local record of the zoom transform and apply it
-     * to all the tracks.
-     */
-    this.zoomTransform = !this.currentProps.zoomable ?
-      zoomIdentity : event.transform;
+    this.zoomTransform = !this.currentProps.zoomable
+      ? zoomIdentity
+      : event.transform;
 
     this.applyZoomTransform(true);
   }
@@ -784,32 +833,27 @@ export class TrackRenderer extends React.Component {
   }
 
   applyZoomTransform(notify = true) {
-    const zoomedXScale = this.zoomTransform.rescaleX(this.xScale);
-    const zoomedYScale = this.zoomTransform.rescaleY(this.yScale);
+    const marginleft = this.currentProps.marginLeft + this.currentProps.leftWidth;
+    const marginTop = this.currentProps.marginTop + this.currentProps.topHeight;
 
-    this.zoomedXScale = zoomedXScale;
-    this.zoomedYScale = zoomedYScale;
+    // These props are apparently used elsewhere, for example the context menu
+    this.zoomedXScale = this.zoomTransform.rescaleX(this.xScale);
+    this.zoomedYScale = this.zoomTransform.rescaleY(this.yScale);
 
     const newXScale = scaleLinear()
-      .domain(
-        [
-          this.currentProps.marginLeft + this.currentProps.leftWidth,
-          this.currentProps.marginLeft + this.currentProps.leftWidth + this.currentProps.centerWidth,
-        ].map(zoomedXScale.invert),
-      )
+      .domain([
+        marginleft, marginleft + this.currentProps.centerWidth
+      ].map(this.zoomedXScale.invert))
       .range([0, this.currentProps.centerWidth]);
 
     const newYScale = scaleLinear()
-      .domain(
-        [
-          this.currentProps.marginTop + this.currentProps.topHeight,
-          this.currentProps.marginTop + this.currentProps.topHeight + this.currentProps.centerHeight,
-        ].map(zoomedYScale.invert),
-      )
+      .domain([
+        marginTop, marginTop + this.currentProps.centerHeight
+      ].map(this.zoomedYScale.invert))
       .range([0, this.currentProps.centerHeight]);
 
     for (const uid in this.trackDefObjects) {
-      if (this.trackDefObjects[uid].trackDef.track.position == 'whole') {
+      if (this.trackDefObjects[uid].trackDef.track.position === 'whole') {
         // whole tracks need different scales which go beyond the ends of
         // center track and encompass the whole view
         const track = this.trackDefObjects[uid].trackObject;
@@ -818,17 +862,15 @@ export class TrackRenderer extends React.Component {
           .domain([
             this.currentProps.marginLeft,
             this.currentProps.width - this.currentProps.marginLeft]
-            .map(zoomedXScale.invert))
-          .range([0, this.currentProps.width - 2*this.currentProps.marginLeft]);
+            .map(this.zoomedXScale.invert))
+          .range([0, this.currentProps.width - (2 * this.currentProps.marginLeft)]);
 
         const trackYScale = scaleLinear()
           .domain([
             this.currentProps.marginTop,
             this.currentProps.height - this.currentProps.marginTop]
-            .map(zoomedYScale.invert))
-          .range([0, this.currentProps.height - 2*this.currentProps.marginTop]);
-
-        // console.log('track.yPosition:', track.yPosition, 'trackYScale.range():', trackYScale.range());
+            .map(this.zoomedYScale.invert))
+          .range([0, this.currentProps.height - (2 * this.currentProps.marginTop)]);
 
         track.zoomed(
           trackXScale,
@@ -852,6 +894,9 @@ export class TrackRenderer extends React.Component {
     if (notify) {
       this.currentProps.onScalesChanged(newXScale, newYScale);
     }
+
+    this.currentXScale = newXScale.copy();
+    this.currentYScale = newYScale.copy();
 
     return [newXScale, newYScale];
   }
@@ -1385,6 +1430,9 @@ TrackRenderer.propTypes = {
   height: PropTypes.number,
   initialXDomain: PropTypes.array,
   initialYDomain: PropTypes.array,
+  xDomainLimits: PropTypes.array,
+  yDomainLimits: PropTypes.array,
+  zoomDomain: PropTypes.array,
   isRangeSelection: PropTypes.bool,
   leftWidth: PropTypes.number,
   marginLeft: PropTypes.number,

--- a/app/scripts/TrackRenderer.js
+++ b/app/scripts/TrackRenderer.js
@@ -894,10 +894,6 @@ export class TrackRenderer extends React.Component {
     if (notify) {
       this.currentProps.onScalesChanged(newXScale, newYScale);
     }
-
-    this.currentXScale = newXScale.copy();
-    this.currentYScale = newYScale.copy();
-
     return [newXScale, newYScale];
   }
 


### PR DESCRIPTION
Limit translation: is agnostic to initial zoom level, i.e., if you initialize by seeing everything you see everything but upon zooming in only the area within the limits will be panable.

E.g., the following allows only panning in chr12
```xDomainLimits: [1950914406, 1950914406 + 133851895],
yDomainLimits: [1950914406, 1950914406 + 133851895],```

Limit scale: you can also limit the scale but make sure to understand that this limit is relative and based on the initial domain. E.g., if you start off at chr12 then you cannot zoom out but only zoom in. If you start at chr1-chrM then you see everything
zoomLimits: [1, Infinity],