### PR TITLE
Add some "data-" attributes to menu elements for targeting w. CSS3. + Resize ViewHeaders after parent resize.

### DIFF
--- a/app/scripts/ConfigTrackMenu.js
+++ b/app/scripts/ConfigTrackMenu.js
@@ -34,6 +34,7 @@ class ConfigTrackMenu extends mix(ContextMenuContainer).with(SeriesListSubmenuMi
     return (
       <div
         ref={c => this.div = c}
+        data-menu-type="ConfigTrackMenu"
         style={{
           left: this.state.left,
           top: this.state.top,

--- a/app/scripts/ConfigViewMenu.js
+++ b/app/scripts/ConfigViewMenu.js
@@ -106,6 +106,7 @@ class ConfigViewMenu extends ContextMenuContainer {
     return (
       <div
         ref={c => this.div = c}
+        data-menu-type="ConfigViewMenu"
         style={{
           left: this.state.left,
           top: this.state.top,

--- a/app/scripts/ContextMenuItem.js
+++ b/app/scripts/ContextMenuItem.js
@@ -6,6 +6,7 @@ import '../styles/ContextMenu.module.scss';
 
 const ContextMenuItem = props => (
   <div
+    data-menu-item-for={typeof props.children === 'string' ? props.children : null}
     onClick={e => props.onClick(e)}
     onMouseEnter={e => props.onMouseEnter(e)}
     onMouseLeave={e => props.onMouseLeave(e)}
@@ -13,9 +14,7 @@ const ContextMenuItem = props => (
     styleName="context-menu-item"
     tabIndex={0}
   >
-    <span
-      styleName="context-menu-span"
-    >
+    <span styleName="context-menu-span">
       {props.children}
     </span>
   </div>

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -574,6 +574,7 @@ class HiGlassComponent extends React.Component {
     this.updateRowHeight();
     this.fitPixiToParentContainer();
     this.refreshView(LONG_DRAG_TIMEOUT);
+    this.resizeHandler();
   }
 
   onBreakpointChange(breakpoint) {

--- a/app/scripts/SeriesListMenu.js
+++ b/app/scripts/SeriesListMenu.js
@@ -295,6 +295,7 @@ export default class SeriesListMenu extends ContextMenuContainer {
       <div
         onMouseLeave={this.props.handleMouseLeave}
         ref={c => this.div = c}
+        data-menu-type="SeriesListMenu"
         style={{
           left: this.state.left,
           top: this.state.top,

--- a/app/scripts/ViewContextMenu.js
+++ b/app/scripts/ViewContextMenu.js
@@ -37,6 +37,7 @@ class ViewContextMenu extends mix(ContextMenuContainer).with(SeriesListSubmenuMi
     return (
       <div
         ref={(c) => { this.div = c; }}
+        data-menu-type="ViewContextMenu"
         style={{
           left: this.state.left,
           top: this.state.top,


### PR DESCRIPTION
#### Add a couple of props/attributes to rendered DOM menu elements to simplify how they might be targeted via CSS.

- Adds "data-menu-type" to contextual menus to help identify what the menu is related to.
- Adds "data-menu-item-for" to contextual menu items to help identify them re: their contents.


![Rendered DOM for drop-down menus](https://i.gyazo.com/77b2ca42db2ad7e6c827bfe095e958b1.png)

In future, would be utilized by 4DN to selectively hide certain menu items/options, e.g.:
```css
.hg-popup > .ContextMenu-module_context-menu-2OwvL[data-menu-type="ConfigTrackMenu"] > .ContextMenu-module_context-menu-item-1HeVv[data-menu-item-for="Add series"] {
    display: none;
}
```

----

#### Resize ViewHeaders after parent resize - 
Call `this.resizeHandler()` from `this.updateAfterResize` to update whether chromosome search input element is visible or not -- **[Preview](https://gyazo.com/c178d8edde927dcd75272884bcdcd812)**
