### PR TITLE
I think this is everywhere that same-origin is required.

### DIFF
--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -2319,7 +2319,8 @@ class HiGlassComponent extends React.Component {
           'Content-Type': 'application/json',
           'X-Requested-With': 'XMLHttpRequest',
         },
-        body: `{"viewconf":${this.getViewsAsString()}}`
+        body: `{"viewconf":${this.getViewsAsString()}}`,
+        credentials: 'same-origin',
       }
     )
       .then( response => {

--- a/app/scripts/services/chrom-info.js
+++ b/app/scripts/services/chrom-info.js
@@ -14,7 +14,7 @@ const parseChromInfo = (text) => {
   return parseChromsizesRows(tsv);
 };
 
-const getFromRemote = url => fetch(url)
+const getFromRemote = url => fetch(url, {credentials: 'same-origin'})
   .then(response => response.text())
   .then(text => parseChromInfo(text))
   .catch((error) => {

--- a/app/scripts/services/tile-proxy.js
+++ b/app/scripts/services/tile-proxy.js
@@ -552,6 +552,7 @@ function json(url, callback) {
 
   const r = request(url)
     .header('Content-Type', 'application/json')
+  // TODO: Check if this preserves same-origin cookies
 
   if (authHeader)
     r.header('Authorization', `${authHeader}`)

--- a/app/scripts/worker.js
+++ b/app/scripts/worker.js
@@ -275,7 +275,8 @@ export function workerGetTiles(outUrl, server, theseTileIds, authHeader, done) {
     headers['Authorization'] = authHeader;
 
   fetch(outUrl, {
-      headers,
+      credentials: 'same-origin',
+      headers: headers
     }
     )
     .then(response => {


### PR DESCRIPTION
Not sure about the behavior of d3-requests.

I was a little confused by worker.js, but this looks like the appropriate translation if we're adding more to the init: (Request and fetch have the same signature.)
```javascript
headers = {'content-type': 'application/json'};
r = new Request('http://example.com', {headers});
console.log('Headers:', Array.from(r.headers.keys()));
console.log('Credentials:', r.credentials);
// Headers: Array [ "content-type" ]
// Credentials: omit 

headers = {'content-type': 'application/json'};
r = new Request('http://example.com', {'headers': headers, 'credentials': 'same-origin'});
console.log('Headers:', Array.from(r.headers.keys()));
console.log('Credentials:', r.credentials);
// Headers: Array [ "content-type" ]
// Credentials: same-origin
```