### PR TITLE
Choose first view ID if `viewId` is undefined and there is only one few

### DIFF
--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -349,7 +349,7 @@ class HiGlassComponent extends React.Component {
       }
     });
 
-    const rendererOptions = 
+    const rendererOptions =
         {
           view: this.canvasElement,
           antialias: true,
@@ -2399,7 +2399,7 @@ class HiGlassComponent extends React.Component {
     if (this.zoomLocks[viewUid]) {
       const lockGroup = this.zoomLocks[viewUid];
       const lockGroupItems = dictItems(lockGroup);
-      
+
       for (let i = 0; i < lockGroupItems.length; i++) {
         const key = lockGroupItems[i][0];
 
@@ -2935,6 +2935,12 @@ class HiGlassComponent extends React.Component {
       return;
     }
 
+    console.log(viewId, viewsIds.length);
+
+    viewId = typeof viewId === 'undefined' && viewsIds.length === 1
+      ? viewsIds[0]
+      : viewId;
+
     if (
       typeof viewId === 'undefined' || viewsIds.indexOf(viewId) === -1
     ) {
@@ -2961,7 +2967,12 @@ class HiGlassComponent extends React.Component {
 
     // Convert scales into genomic locations
     const middleLayerListener = (xScale, yScale) => {
-      callback({xDomain: xScale.domain(), yDomain: yScale.domain(), xRange: xScale.range(), yRange: yScale.range() });
+      callback({
+        xDomain: xScale.domain(),
+        yDomain: yScale.domain(),
+        xRange: xScale.range(),
+        yRange: yScale.range()
+      });
     };
 
     let newListenerId = 1;


### PR DESCRIPTION
If you have only one view and you want to listen to its location changes you can now be lazy and do:

```javascript
const hgApi = hglib.viewer(document.getElementById('demo'), viewConfig, { bounded: true });
hgApi.on('location', (...location) => { console.log(...location); });
```

I.e., you don't have to specify the actual view id. By default if there's only one view and you haven't specified any view id HiGlass will pick the first (and only) available view.