### PR TITLE
Flekschas/fix 291

### DIFF
--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -494,7 +494,7 @@ class HiGlassComponent extends React.Component {
   }
 
   mousewheelHandler(e) {
-    if (hasParent(e.target, this.topDiv)) {
+    if (hasParent(e.target, this.topDiv) && !this.isZoomFixed()) {
       e.preventDefault();
     }
   }

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -159,15 +159,6 @@ class HiGlassComponent extends React.Component {
       );
     }
 
-    this.pubSubs.push(pubSub.subscribe('requestReceived', () => {
-      if (!this.viewconfLoaded && requestsInFlight == 0) {
-        this.viewconfLoaded = true;
-        if (this.props.options.onViewConfLoaded) {
-          this.props.options.onViewConfLoaded();
-        }
-      }
-    }));
-
     if (props.options.authToken) {
       setTileProxyAuthHeader(props.options.authToken);
     }
@@ -245,6 +236,24 @@ class HiGlassComponent extends React.Component {
 
     this.prevMouseHoverTrack = null;
     this.zooming = false;
+
+    // Bounded functions
+    this.keyDownHandlerBound = this.keyDownHandler.bind(this);
+    this.keyUpHandlerBound = this.keyUpHandler.bind(this);
+    this.resizeHandlerBound = this.resizeHandler.bind(this);
+    this.mousewheelHandlerBound = this.mousewheelHandler.bind(this);
+    this.resizeHandlerBound = this.resizeHandler.bind(this);
+    this.dispatchEventBound = this.dispatchEvent.bind(this);
+    this.animateOnMouseMoveHandlerBound = this.animateOnMouseMoveHandler.bind(this);
+    this.zoomStartHandlerBound = this.zoomStartHandler.bind(this);
+    this.zoomEndHandlerBound = this.zoomEndHandler.bind(this);
+    this.zoomHandlerBound = this.zoomHandler.bind(this);
+    this.trackDroppedHandlerBound = this.trackDroppedHandler.bind(this);
+    this.animateBound = this.animate.bind(this);
+    this.requestReceivedHandlerBound = this.requestReceivedHandler.bind(this);
+    this.onWheelHandlerBound = this.onWheelHandler.bind(this);
+    this.mouseMoveHandlerBound = this.mouseMoveHandler.bind(this);
+    this.onMouseLeaveHandlerBound = this.onMouseLeaveHandler.bind(this);
   }
 
   componentWillMount() {
@@ -260,42 +269,18 @@ class HiGlassComponent extends React.Component {
     domEvent.register('mousemove', window);
 
     this.pubSubs.push(
-      pubSub.subscribe('keydown', this.keyDownHandler.bind(this))
-    );
-    this.pubSubs.push(
-      pubSub.subscribe('keyup', this.keyUpHandler.bind(this))
-    );
-    this.pubSubs.push(
-      pubSub.subscribe('resize', this.resizeHandler.bind(this))
-    );
-    this.pubSubs.push(
-      pubSub.subscribe('mousewheel', this.mousewheelHandler.bind(this))
-    );
-    this.pubSubs.push(
-      pubSub.subscribe('orientationchange', this.resizeHandler.bind(this))
-    );
-    this.pubSubs.push(
-      pubSub.subscribe('app.event', this.dispatchEvent.bind(this))
-    );
-    this.pubSubs.push(
-      pubSub.subscribe('app.animateOnMouseMove', this.animateOnMouseMoveHandler.bind(this))
-    );
-
-    this.pubSubs.push(
-      pubSub.subscribe('trackDropped', () => {
-        this.setState({
-          draggingHappening: null,
-        });
-      }),
-      pubSub.subscribe('app.zoomStart', this.zoomStartHandler.bind(this))
-    );
-
-    this.pubSubs.push(
-      pubSub.subscribe('app.zoomEnd', this.zoomEndHandler.bind(this))
-    );
-
-    this.pubSubs.push(
-      pubSub.subscribe('app.zoom', this.zoomHandler.bind(this))
+      pubSub.subscribe('keydown', this.keyDownHandlerBound),
+      pubSub.subscribe('keyup', this.keyUpHandlerBound),
+      pubSub.subscribe('resize', this.resizeHandlerBound),
+      pubSub.subscribe('mousewheel', this.mousewheelHandlerBound),
+      pubSub.subscribe('orientationchange', this.resizeHandlerBound),
+      pubSub.subscribe('app.event', this.dispatchEventBound),
+      pubSub.subscribe('app.animateOnMouseMove', this.animateOnMouseMoveHandlerBound),
+      pubSub.subscribe('trackDropped', this.trackDroppedHandlerBound),
+      pubSub.subscribe('app.zoomStart', this.zoomStartHandlerBound),
+      pubSub.subscribe('app.zoomEnd', this.zoomEndHandlerBound),
+      pubSub.subscribe('app.zoom', this.zoomHandlerBound),
+      pubSub.subscribe('requestReceived', this.requestReceivedHandlerBound),
     );
 
     if (this.props.getApi) {
@@ -339,7 +324,9 @@ class HiGlassComponent extends React.Component {
     this.mounted = true;
     this.element = ReactDOM.findDOMNode(this);
     window.addEventListener('focus', this.boundRefreshView);
-    window.addEventListener('mousewheel', this.mousewheelHandler.bind(this), true);
+
+    // The mousewheel is already listened to. This handler is also never removed
+    // window.addEventListener('mousewheel', this.mousewheelHandler.bind(this), true);
 
     dictValues(this.state.views).forEach((v) => {
       if (!v.layout) {
@@ -349,7 +336,7 @@ class HiGlassComponent extends React.Component {
       }
     });
 
-    const rendererOptions = 
+    const rendererOptions =
         {
           view: this.canvasElement,
           antialias: true,
@@ -507,14 +494,29 @@ class HiGlassComponent extends React.Component {
   }
 
   mousewheelHandler(e) {
-    if (hasParent(e.target, this.topDiv)) e.preventDefault();
+    if (hasParent(e.target, this.topDiv)) {
+      e.preventDefault();
+    }
+  }
+
+  trackDroppedHandler() {
+    this.setState({
+      draggingHappening: null,
+    });
+  }
+
+  requestReceivedHandler() {
+    if (!this.viewconfLoaded && requestsInFlight == 0) {
+      this.viewconfLoaded = true;
+      if (this.props.options.onViewConfLoaded) {
+        this.props.options.onViewConfLoaded();
+      }
+    }
   }
 
   animateOnMouseMoveHandler(active) {
     if (active && !this.animateOnMouseMove) {
-      this.pubSubs.push(
-        pubSub.subscribe('app.mouseMove', this.animate.bind(this)),
-      );
+      this.pubSubs.push(pubSub.subscribe('app.mouseMove', this.animateBound));
     }
     this.animateOnMouseMove = active;
   }
@@ -2399,7 +2401,7 @@ class HiGlassComponent extends React.Component {
     if (this.zoomLocks[viewUid]) {
       const lockGroup = this.zoomLocks[viewUid];
       const lockGroupItems = dictItems(lockGroup);
-      
+
       for (let i = 0; i < lockGroupItems.length; i++) {
         const key = lockGroupItems[i][0];
 
@@ -3176,6 +3178,39 @@ class HiGlassComponent extends React.Component {
     });
   }
 
+  onMouseLeaveHandler() {
+    this.hideHoverMenu();
+  }
+
+  isZoomFixed(view) {
+    return (
+      this.props.zoomFixed
+      || this.props.options.zoomFixed
+      || this.props.viewConfig.zoomFixed
+      || (view && view.zoomFixed)
+    );
+  }
+
+  onWheelHandler(evt) {
+    const zoomFixed = (
+      this.props.zoomFixed
+      || this.props.options.zoomFixed
+      || this.props.viewConfig.zoomFixed
+    );
+
+    if (evt.forwared || zoomFixed) return;
+
+    // forward the wheel event back to the TrackRenderer that it should go to
+    // this is so that we can zoom when there's a viewport projection present
+    const hoveredTiledPlot = this.getTiledPlotAtPosition(evt.clientX, evt.clientY);
+    if (hoveredTiledPlot) {
+      const trackRenderer = hoveredTiledPlot.trackRenderer;
+      evt.forwared = true;
+
+      forwardEvent(evt.nativeEvent, trackRenderer.element);
+    }
+  }
+
   render() {
     this.tiledAreasDivs = {};
     this.tiledAreas = (
@@ -3188,10 +3223,7 @@ class HiGlassComponent extends React.Component {
     // the right width
     if (this.mounted) {
       this.tiledAreas = dictValues(this.state.views).map((view) => {
-        let zoomFixed = typeof view.zoomFixed !== 'undefined'
-          ? view.zoomFixed
-          : this.props.zoomFixed;
-        zoomFixed = zoomFixed | this.props.viewConfig.zoomFixed;
+        const zoomFixed = this.isZoomFixed(view);
 
         // only show the add track menu for the tiled plot it was selected for
         const addTrackPositionMenuPosition =
@@ -3462,23 +3494,9 @@ class HiGlassComponent extends React.Component {
         key={this.uid}
         ref={(c) => { this.topDiv = c; }}
         className='higlass'
-        onMouseMove={this.mouseMoveHandler.bind(this)}
-        onMouseLeave={() => {
-          this.hideHoverMenu();
-        }}
-        onWheel={ (evt) => {
-          if (evt.forwared)
-            return;
-          // forward the wheel event back to the TrackRenderer that it should go to
-          // this is so that we can zoom when there's a viewport projection present
-          const hoveredTiledPlot = this.getTiledPlotAtPosition(evt.clientX, evt.clientY);
-          if (hoveredTiledPlot) {
-            const trackRenderer = hoveredTiledPlot.trackRenderer;
-            evt.forwared = true;
-
-            forwardEvent(evt.nativeEvent, trackRenderer.element);
-          }
-        }}
+        onMouseMove={this.mouseMoveHandlerBound}
+        onMouseLeave={this.onMouseLeaveHandlerBound}
+        onWheel={this.onWheelHandlerBound}
         styleName={styleNames}
       >
         <canvas

--- a/app/scripts/TrackRenderer.js
+++ b/app/scripts/TrackRenderer.js
@@ -411,7 +411,7 @@ class TrackRenderer extends React.Component {
   }
 
   addZoom() {
-    if (!this.elementSelection) return;
+    if (!this.elementSelection || !this.currentProps.zoomable) return;
 
     // add back the previous transform
     this.elementSelection.call(this.zoomBehavior);

--- a/app/test-zoom-fixed-scroll.html
+++ b/app/test-zoom-fixed-scroll.html
@@ -1,0 +1,234 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>HiGlass</title>
+<style type="text/css">
+    .canvasjs-chart-credit {
+    display:none;
+}
+</style>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <link rel="stylesheet" href="styles/page.css">
+    <link rel="stylesheet" href="hglib.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.6.2/react.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/15.6.2/react-dom.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/4.6.2/pixi.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/react-bootstrap/0.31.0/react-bootstrap.min.js"></script>
+</head>
+<body >
+    <div>
+        <div style="width: 100%; height: 250px;"></div>
+        <div
+          id="demo"
+          style="prosition: relative; width: 100%; height: 500px">
+        </div>
+        <div style="width: 100%; height: 1000px;"></div>
+    </div>
+</body>
+<script src='hglib.js'>
+</script>
+<script>
+
+const viewConfig = {
+  editable: true,
+  zoomFixed: false,
+  trackSourceServers: [
+    'http://higlass.io/api/v1'
+  ],
+  exportViewUrl: 'http://higlass.io/api/v1/viewconfs/',
+  views: [
+    {
+      uid: 'aa',
+      initialXDomain: [
+        7595655.0000270605,
+        2507738795.9999733
+      ],
+      initialYDomain: [
+        -545671929.4383738,
+        3061006380.438374
+      ],
+      autocompleteSource: 'http://higlass.io/api/v1/suggest/?d=OHJakQICQD6gTD7skx4EWA&',
+      genomePositionSearchBoxVisible: false,
+      chromInfoPath: '//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv',
+      tracks: {
+        top: [
+          {
+            name: 'wgEncodeSydhTfbsGm12878Ctcfsc15914c20StdSig',
+            created: '2017-02-03T17:46:58.349271Z',
+            server: 'http://higlass.io/api/v1',
+            tilesetUid: 'b6qFe7fOSnaX-YkP2kzN1w',
+            uid: 'WCGssXHmQTGOkdRgweYKkQ',
+            type: 'horizontal-bar',
+            options: {
+              labelColor: 'black',
+              labelPosition: 'topLeft',
+              axisPositionHorizontal: 'right',
+              barFillColor: 'darkgreen',
+              valueScaling: 'linear',
+              trackBorderWidth: 0,
+              trackBorderColor: 'black',
+              labelTextOpacity: 0.4,
+              barOpacity: 1,
+              name: 'wgEncodeSydhTfbsGm12878Ctcfsc15914c20StdSig'
+            },
+            width: 479,
+            height: 20,
+            position: 'top'
+          },
+          {
+            name: 'Gene Annotations (hg19)',
+            server: 'http://higlass.io/api/v1',
+            tilesetUid: 'OHJakQICQD6gTD7skx4EWA',
+            uid: 'BEEMEjU7QCa2krDO9C0yOQ',
+            type: 'horizontal-gene-annotations',
+            options: {
+              labelPosition: 'outerTop',
+              name: 'Gene Annotations (hg19)',
+              labelColor: 'black',
+              plusStrandColor: 'blue',
+              minusStrandColor: 'red',
+              trackBorderWidth: 0,
+              trackBorderColor: 'black',
+              showMousePosition: false,
+              mousePositionColor: '#999999'
+            },
+            width: 479,
+            height: 60,
+            position: 'top',
+          },
+          {
+            chromInfoPath: '//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv',
+            type: 'horizontal-chromosome-labels',
+            position: 'top',
+            name: 'Chromosome Labels (hg19)',
+            height: 30,
+            uid: 'I1QUF22JQJuJ38j9PS4iqw',
+            options: {
+              showMousePosition: false,
+              mousePositionColor: '#999999'
+            },
+            width: 479
+          }
+        ],
+        left: [
+          {
+            name: 'wgEncodeSydhTfbsGm12878Ctcfsc15914c20StdSig',
+            created: '2017-02-03T17:46:58.349271Z',
+            server: 'http://higlass.io/api/v1',
+            tilesetUid: 'b6qFe7fOSnaX-YkP2kzN1w',
+            uid: 'WCGssXHmQTGOkdRgweYKkQ2',
+            type: 'vertical-bar',
+            options: {
+              labelColor: 'black',
+              labelPosition: 'topLeft',
+              axisPositionHorizontal: 'right',
+              barFillColor: 'darkgreen',
+              valueScaling: 'linear',
+              trackBorderWidth: 0,
+              trackBorderColor: 'black',
+              labelTextOpacity: 0.4,
+              barOpacity: 1,
+              name: 'wgEncodeSydhTfbsGm12878Ctcfsc15914c20StdSig'
+            },
+          },
+          {
+            name: 'Gene Annotations (hg19)',
+            server: 'http://higlass.io/api/v1',
+            tilesetUid: 'OHJakQICQD6gTD7skx4EWA',
+            uid: 'BEEMEjU7QCa2krDO9C0yOQ2',
+            type: 'vertical-gene-annotations',
+            options: {
+              labelPosition: 'outerTop',
+              name: 'Gene Annotations (hg19)',
+              labelColor: 'black',
+              plusStrandColor: 'blue',
+              minusStrandColor: 'red',
+              trackBorderWidth: 0,
+              trackBorderColor: 'black',
+              showMousePosition: false,
+              mousePositionColor: '#999999'
+            },
+          },
+          {
+            chromInfoPath: '//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv',
+            type: 'vertical-chromosome-labels',
+            position: 'top',
+            name: 'Chromosome Labels (hg19)',
+            height: 30,
+            uid: 'I1QUF22JQJuJ38j9PS4iqw2',
+            options: {
+              showMousePosition: false,
+              mousePositionColor: '#999999'
+            },
+          }
+        ],
+        center: [{
+          uid: 'c1',
+          type: 'combined',
+          height: 691,
+          contents: [
+            {
+              server: 'http://higlass.io/api/v1',
+              tilesetUid: 'CQMd6V_cRw6iCI_-Unl3PQ',
+              type: 'heatmap',
+              position: 'center',
+              options: {
+                colorRange: [
+                  '#FFFFFF',
+                  '#F8E71C',
+                  '#F5A623',
+                  '#D0021B'
+                ],
+                colorbarPosition: 'topRight',
+                colorbarLabelsPosition: 'outside',
+                maxZoom: null,
+                labelPosition: 'bottomLeft',
+                name: 'Rao et al. (2014) GM12878 MboI (allreps) 1kb',
+                trackBorderWidth: 0,
+                trackBorderColor: 'black',
+                heatmapValueScaling: 'log',
+                scaleStartPercent: '0.00000',
+                scaleEndPercent: '1.00000',
+                backgroundColor: '#eeeeee',
+                showMousePosition: false,
+                mousePositionColor: '#999999',
+                showTooltip: false
+              },
+              uid: 'heatmap1',
+              name: 'Rao et al. (2014) GM12878 MboI (allreps) 1kb',
+              transforms: [
+                {
+                  name: 'ICE',
+                  value: 'weight'
+                }
+              ],
+              width: 479,
+              height: 691
+            },
+          ],
+        }],
+        right: [],
+        bottom: [],
+      },
+      layout: {
+        w: 12,
+        h: 12,
+        x: 0,
+        y: 0,
+        i: 'aa',
+        moved: false,
+        static: false
+      },
+    }
+  ],
+};
+
+window.hgApi = hglib.viewer(
+  document.getElementById('demo'),
+  viewConfig,
+  { bounded: true, zoomFixed: true },
+);
+
+</script>
+</html>


### PR DESCRIPTION
- Fix #291 
- Avoids on-the-fly context binding via `.bind(this)` for event listeners as this can impose memory leaks
- Enables setting `zoomFixed` via the options like so

```javascript
window.hgApi = hglib.viewer(
  document.getElementById('demo'),
  viewConfig,
  { bounded: true, zoomFixed: true },
);
```